### PR TITLE
feat: Add Architecture Templates dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,19 @@
       </div>
 
       <div class="widget-title" style="margin-top: 20px;">Layer Architecture</div>
+
+      <!-- {{ Add Architecture Template Dropdown }} -->
+      <div class="input-group">
+          <label for="architectureTemplateSelect">Architecture Template:</label>
+          <select id="architectureTemplateSelect">
+              <option value="custom" selected>Custom</option>
+              <option value="mlp">Simple MLP</option>
+              <option value="autoencoder">Basic Autoencoder</option>
+              <!-- Add more templates here in the future -->
+          </select>
+      </div>
+      <!-- {{ End Dropdown }} -->
+
        <div class="input-group">
          <label for="numHiddenLayers" title="Number of layers between input and output. More layers allow for more complex patterns but increase training time/risk of overfitting.">Number of Hidden Layers:</label>
          <input type="number" id="numHiddenLayers" value="2" min="0">
@@ -724,6 +737,31 @@
         const lrSchedulerSelect = document.getElementById('lrScheduler');
         const lrStepParamsDiv = document.getElementById('lrStepParams');
         const lrExpParamsDiv = document.getElementById('lrExpParams');
+        // {{ Add reference to template select }}
+        const architectureTemplateSelect = document.getElementById('architectureTemplateSelect');
+
+        // {{ Define Architecture Templates }}
+        const architectureTemplates = {
+            'mlp': {
+                numHidden: 2,
+                layers: [
+                    { type: 'dense', size: 16, activation: 'relu', useBias: true },
+                    { type: 'dense', size: 8, activation: 'relu', useBias: true }
+                ]
+            },
+            'autoencoder': {
+                numHidden: 3,
+                layers: [
+                    { type: 'dense', size: 16, activation: 'relu', useBias: true }, // Encoder
+                    { type: 'dense', size: 4, activation: 'relu', useBias: true },  // Bottleneck
+                    { type: 'dense', size: 16, activation: 'relu', useBias: true }  // Decoder
+                ],
+                // Special hint for final layer config during training
+                finalActivationHint: 'sigmoid' // Suggest sigmoid if inputs are 0-1, or 'none' otherwise
+            }
+            // Add more templates here
+        };
+        // {{ End Template Definitions }}
 
         function generateRandomData(numSamples, numInputs, numOutputs = 1, noiseLevel = 0.05) { if (numInputs <= 0 || numOutputs <= 0) return ""; const data = []; for (let i = 0; i < numSamples; i++) { const input = []; for (let j = 0; j < numInputs; j++) input.push(Math.random()); const output = []; for (let j = 0; j < numOutputs; j++) { const base = Math.sin(input[0] * Math.PI * 2) * 0.4 + 0.5; const noise = (Math.random() - 0.5) * 2 * noiseLevel; let final = Math.max(0.01, Math.min(0.99, base + noise)); output.push(final); } data.push([...input, ...output].map(v => v.toFixed(3)).join(', ')); } return data.join('\n'); }
         document.getElementById("loadDataBtn").onclick = () => { const numTrain=100, numTest=25, numIn=3, numOut=1; trainingDataTextarea.value = generateRandomData(numTrain, numIn, numOut); testDataTextarea.value = generateRandomData(numTest, numIn, numOut); statsEl.innerHTML = `Generated ${numTrain}/${numTest} random samples.`; try { const sample = parseCSV(trainingDataTextarea.value)[0]; if(sample && nn.layers && nn.layers.length > 0) nn.predict(sample.input); } catch (e) {} drawNetwork(); }
@@ -736,11 +774,17 @@
             const layerTypes = ['dense', 'layernorm', 'attention', 'dropout', 'softmax'];
             if (numLayers === 0) { hiddenLayersConfigContainer.innerHTML = '<p class="layer-note">No hidden layers. Direct input-to-output connection (final layer added automatically).</p>'; return; }
             for (let i = 0; i < numLayers; i++) { const layerGroup = document.createElement('div'); layerGroup.className = 'input-group settings-grid'; const typeDiv = document.createElement('div'); typeDiv.className = 'input-group'; const typeLabel = document.createElement('label'); typeLabel.textContent = `Layer ${i+1} Type:`; typeLabel.htmlFor = `layerType_${i}`; typeLabel.title = "Choose the operation for this layer..."; const typeSelect = document.createElement('select'); typeSelect.id = `layerType_${i}`; typeSelect.dataset.layerIndex = i; typeSelect.dataset.configType = 'type'; layerTypes.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; if (t === 'dense') o.selected = true; typeSelect.appendChild(o); }); typeDiv.appendChild(typeLabel); typeDiv.appendChild(typeSelect); layerGroup.appendChild(typeDiv); const optionsDiv = document.createElement('div'); optionsDiv.className = 'layer-options-container'; optionsDiv.dataset.layerIndex = i; layerGroup.appendChild(optionsDiv);
+            // {{ Add listener to layer type select for manual changes }}
+            typeSelect.addEventListener('change', () => architectureTemplateSelect.value = 'custom');
+
             const updateOptionsUI = (idx, selType) => { const optsDiv = hiddenLayersConfigContainer.querySelector(`.layer-options-container[data-layer-index='${idx}']`); if (!optsDiv) return; optsDiv.innerHTML = ''; const createIn = (l,id,t,v,mn,st,cfg,nt=null,tt=null)=>{const dv=document.createElement('div'); dv.className='input-group'; const lb=document.createElement('label'); lb.textContent=l; lb.htmlFor=id; if(tt)lb.title=tt; const ip=document.createElement('input'); ip.type=t; ip.id=id; ip.value=v; if(mn!==null)ip.min=mn; if(st!==null)ip.step=st; ip.dataset.layerIndex=idx; ip.dataset.configType=cfg; dv.appendChild(lb); dv.appendChild(ip); if(nt){const p=document.createElement('p');p.className='layer-note';p.textContent=nt;dv.appendChild(p);} return dv;}; const createSel = (l,id,opts,selV,cfg,tt=null)=>{const dv=document.createElement('div'); dv.className='input-group'; const lb=document.createElement('label'); lb.textContent=l; lb.htmlFor=id; if(tt)lb.title=tt; const sel=document.createElement('select'); sel.id=id; sel.dataset.layerIndex=idx; sel.dataset.configType=cfg; opts.forEach(o=>{const op=document.createElement('option'); op.value=o; op.textContent=o; if(o===selV)op.selected=true; sel.appendChild(op);}); dv.appendChild(lb); dv.appendChild(sel); return dv;}; const createChk=(l,id,chkd,cfg,tt=null)=>{const dv=document.createElement('div'); dv.className='input-group'; const lb=document.createElement('label'); const ip=document.createElement('input'); ip.type='checkbox'; ip.id=id; ip.checked=chkd; ip.dataset.layerIndex=idx; ip.dataset.configType=cfg; const sp=document.createElement('span'); sp.textContent=l; if(tt)sp.title=tt; lb.appendChild(ip); lb.appendChild(sp); dv.appendChild(lb); return dv;}; const createNt=(txt)=>{const p=document.createElement('p'); p.className='layer-note'; p.textContent=txt; const dv=document.createElement('div'); dv.style.gridColumn='1/-1'; dv.appendChild(p); return dv;};
             if(selType==='dense'){optsDiv.appendChild(createIn('Nodes:',`layerNodes_${idx}`, 'number', 10, 1, 1, 'size', null,"Num neurons.")); optsDiv.appendChild(createSel('Activation:',`layerAct_${idx}`, activationTypes, 'tanh', 'activation', "Neuron output function.")); optsDiv.appendChild(createChk('Use Bias:',`layerBias_${idx}`, true, 'useBias', "Add learnable bias term?"));} else if(selType==='attention'){optsDiv.appendChild(createIn('Num Heads:',`layerHeads_${idx}`, 'number', 2, 1, 1, 'numHeads', null,"Parallel attention mechanisms. Input size must be divisible by heads.")); optsDiv.appendChild(createNt('Input size must be divisible by Num Heads. Output size matches input.'));} else if(selType==='layernorm'){optsDiv.appendChild(createNt('Normalizes features across the feature dimension.'));} else if(selType==='dropout'){optsDiv.appendChild(createIn('Dropout Rate:',`layerRate_${idx}`, 'number', 0.5, 0, 0.01, 'rate', 'Fraction of neurons to zero out during training (0 to <1). Helps prevent overfitting.',"Higher value means more dropout."));} else if(selType==='softmax'){optsDiv.appendChild(createNt('Outputs probabilities summing to 1. For multi-class classification.'));}};
             typeSelect.addEventListener('change', (event) => updateOptionsUI(i, event.target.value)); hiddenLayersConfigContainer.appendChild(layerGroup); updateOptionsUI(i, typeSelect.value); }
         }
-        numHiddenLayersInput.addEventListener('change', (event) => { const numLayers = Math.max(0, parseInt(event.target.value) || 0); event.target.value = numLayers; createLayerConfigUI(numLayers); }); createLayerConfigUI(parseInt(numHiddenLayersInput.value));
+        numHiddenLayersInput.addEventListener('change', (event) => { const numLayers = Math.max(0, parseInt(event.target.value) || 0); event.target.value = numLayers; createLayerConfigUI(numLayers);
+        // {{ Reset template dropdown on manual layer count change }}
+        architectureTemplateSelect.value = 'custom';
+        }); createLayerConfigUI(parseInt(numHiddenLayersInput.value));
         optimizerSelect.addEventListener('change', () => { decayRateGroup.style.display = optimizerSelect.value === 'rmsprop' ? 'block' : 'none'; }); decayRateGroup.style.display = optimizerSelect.value === 'rmsprop' ? 'block' : 'none';
 
         lrSchedulerSelect.addEventListener('change', () => {
@@ -748,8 +792,68 @@
             lrStepParamsDiv.style.display = selectedSchedule === 'step' ? 'grid' : 'none'; // Use grid for settings-grid
             lrExpParamsDiv.style.display = selectedSchedule === 'exponential' ? 'grid' : 'none'; // Use grid for settings-grid
         });
-        // Initial check in case the page loads with a schedule selected (e.g., after model load)
         lrSchedulerSelect.dispatchEvent(new Event('change'));
+
+        // {{ Add Template Selector Logic }}
+        architectureTemplateSelect.addEventListener('change', (event) => {
+            const templateKey = event.target.value;
+            if (templateKey === 'custom') {
+                // Allow manual configuration, do nothing here
+                return;
+            }
+
+            const template = architectureTemplates[templateKey];
+            if (!template) {
+                console.warn("Selected template not found:", templateKey);
+                return;
+            }
+
+            statsEl.innerHTML = `Applying '${templateKey}' template...`;
+
+            // 1. Set number of hidden layers
+            numHiddenLayersInput.value = template.numHidden;
+
+            // 2. Trigger change to regenerate UI (IMPORTANT)
+            numHiddenLayersInput.dispatchEvent(new Event('change'));
+
+            // 3. Use setTimeout to allow DOM update before populating
+            setTimeout(() => {
+                try {
+                    template.layers.forEach((layerConfig, i) => {
+                        const setV=(s,v)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e&&v!==undefined)e.value=v;};
+                        const setC=(s,c)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e&&c!==undefined)e.checked=c;};
+                        const triggerChange=(s)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e) e.dispatchEvent(new Event('change',{bubbles:true}));}; // Helper to trigger change
+
+                        // Set layer type first and trigger change to update options UI
+                        setV(`select[data-layer-index="${i}"][data-config-type="type"]`, layerConfig.type || 'dense');
+                        triggerChange(`select[data-layer-index="${i}"][data-config-type="type"]`); // Crucial!
+
+                        // Set other config values based on type
+                        switch(layerConfig.type){
+                            case 'dense':
+                                setV(`input[data-layer-index="${i}"][data-config-type="size"]`, layerConfig.size);
+                                setV(`select[data-layer-index="${i}"][data-config-type="activation"]`, layerConfig.activation);
+                                setC(`input[data-layer-index="${i}"][data-config-type="useBias"]`, layerConfig.useBias);
+                                break;
+                            case 'attention':
+                                setV(`input[data-layer-index="${i}"][data-config-type="numHeads"]`, layerConfig.numHeads);
+                                break;
+                            case 'dropout':
+                                setV(`input[data-layer-index="${i}"][data-config-type="rate"]`, layerConfig.rate);
+                                break;
+                            // LayerNorm and Softmax have no specific config values in this simple setup
+                        }
+                    });
+                    statsEl.innerHTML = `Applied '${templateKey}' template. Ready.`;
+                 } catch (error) {
+                     console.error("Error applying template UI:", error);
+                     statsEl.innerHTML = `<span class="error">Error applying template: ${error.message}</span>`;
+                     architectureTemplateSelect.value = 'custom'; // Revert on error
+                 }
+            }, 0); // Timeout needed to ensure createLayerConfigUI finishes DOM manipulation
+        });
+        // {{ End Template Selector Logic }}
+
 
         trainButton.addEventListener('click', async () => {
             statsEl.innerHTML = 'Starting training...'; trainButton.disabled = true; trainButton.textContent = 'Training...'; predictButton.disabled = true; saveButton.disabled = true; loadButton.disabled = true; unloadButton.disabled = true; epochBar.style.width = '0%'; lossHistory = []; drawLossGraph();
@@ -757,7 +861,25 @@
                 const trainingData = parseCSV(trainingDataTextarea.value); const testData = parseCSV(testDataTextarea.value); if (trainingData.length === 0) throw new Error("Training data empty/invalid."); if (!trainingData[0]?.input || !trainingData[0]?.output) throw new Error("Cannot get input/output size from data.");
                 nn.reset(); const numHidden = parseInt(numHiddenLayersInput.value); const layerCfgs = []; const numIns = trainingData[0].input.length; let curInSize = numIns;
                 for (let i = 0; i < numHidden; i++) { const getV=(s)=>hiddenLayersConfigContainer.querySelector(s)?.value; const getC=(s)=>hiddenLayersConfigContainer.querySelector(s)?.checked; const lType=getV(`select[data-layer-index="${i}"][data-config-type="type"]`) || 'dense'; let cfg={type:lType, inputSize:curInSize}; switch(lType){ case 'dense': cfg.outputSize=parseInt(getV(`input[data-layer-index="${i}"][data-config-type="size"]`)||1); if(cfg.outputSize<=0) throw new Error(`L${i+1} Dense: Invalid nodes.`); cfg.activation=getV(`select[data-layer-index="${i}"][data-config-type="activation"]`) || 'tanh'; cfg.useBias=getC(`input[data-layer-index="${i}"][data-config-type="useBias"]`)??true; break; case 'attention': cfg.numHeads=parseInt(getV(`input[data-layer-index="${i}"][data-config-type="numHeads"]`)||1); if(cfg.numHeads<=0) throw new Error(`L${i+1} Attn: Invalid heads.`); if(curInSize%cfg.numHeads!==0) throw new Error(`L${i+1} Attn: Input ${curInSize} not divisible by ${cfg.numHeads} heads.`); cfg.outputSize=curInSize; break; case 'dropout': cfg.rate=parseFloat(getV(`input[data-layer-index="${i}"][data-config-type="rate"]`)||0); if(cfg.rate<0||cfg.rate>=1) throw new Error(`L${i+1} Dropout: Invalid rate.`); cfg.outputSize=curInSize; break; case 'layernorm': case 'softmax': cfg.outputSize=curInSize; break; default: throw new Error(`L${i+1}: Unknown type "${lType}".`); } if(!cfg.outputSize) throw new Error(`L${i+1}: No output size.`); layerCfgs.push(cfg); curInSize=cfg.outputSize; }
-                const numOuts=trainingData[0].output.length; if(numOuts<=0)throw new Error("Zero output cols."); const finalNeedsSoftmax=lossFunctionSelect.value==='crossentropy'&&numOuts>1; const finalAct=finalNeedsSoftmax?'softmax':'tanh'; console.log(`Adding final dense: ${curInSize}->${numOuts} (Act:${finalAct})`); layerCfgs.push({type:'dense',inputSize:curInSize,outputSize:numOuts,activation:finalAct,useBias:true});
+                // {{ Adjust final layer based on template and data }}
+                const isAutoencoder = architectureTemplateSelect.value === 'autoencoder';
+                const numOuts = isAutoencoder ? numIns : trainingData[0].output.length; // Autoencoder output size matches input size
+                if(numOuts <= 0) throw new Error("Zero output cols defined.");
+
+                const finalNeedsSoftmax = !isAutoencoder && lossFunctionSelect.value === 'crossentropy' && numOuts > 1;
+                let finalAct = 'tanh'; // Default final activation
+                if (finalNeedsSoftmax) {
+                    finalAct = 'softmax';
+                } else if (isAutoencoder) {
+                    // Use hint from template, default to sigmoid/none based on complexity
+                    finalAct = architectureTemplates['autoencoder']?.finalActivationHint || 'sigmoid';
+                    console.log(`Autoencoder detected, using final activation: ${finalAct}`);
+                }
+
+                console.log(`Adding final dense: ${curInSize}->${numOuts} (Act:${finalAct})`);
+                layerCfgs.push({type:'dense', inputSize:curInSize, outputSize:numOuts, activation:finalAct, useBias:true});
+                // {{ End final layer adjustment }}
+
                 layerCfgs.forEach((cfg,i)=>{try{nn.layer(cfg);}catch(e){throw new Error(`Cfg L${i+1}(${cfg.type}): ${e.message}`);}}); if(nn.layers.length===0)throw new Error("Zero layers configured."); if(nn.debug)console.log("Net structure:",nn.layers);
                 const opts={
                     epochs:parseInt(epochsInput.value)||50,
@@ -815,17 +937,17 @@
             // Configs
             const pad=35, maxNds=20, nRBase=2, nRScale=3, cBOp=0.02, cMOp=0.85, cWScale=2, ellOff=10, lblOff=20, lblFnt="10px monospace", lblClr="#aaa";
             const nVizLyrs=nn.lastActivations.length;
-            
+
             // Adjust spacing based on number of layers
             // More spacing for fewer layers, minimum spacing for many layers
             const baseSpacing = 150; // Base spacing between layers (increased from 70)
             const minLayerSpacing = Math.max(120, Math.min(baseSpacing, containerWidth / (nVizLyrs > 1 ? nVizLyrs : 1)));
-            
+
             // Calculate required width with improved spacing
-            const requiredWidth = (nVizLyrs <= 1) 
-                ? containerWidth 
+            const requiredWidth = (nVizLyrs <= 1)
+                ? containerWidth
                 : pad * 2 + (nVizLyrs - 1) * minLayerSpacing;
-            
+
             // Ensure we have at least 20% more space than the minimal calculated width
             // This creates more visual breathing room
             const canvasDrawWidth = Math.max(containerWidth, requiredWidth * 1.2);
@@ -913,21 +1035,21 @@
 
             // 3. Draw Nodes and Labels
             networkCtx.textAlign = "center";
-            
+
             // Draw the "Layers" label centered over all hidden layers
             if (layerXs.length > 2) {
                 // Calculate center position between first hidden layer and last hidden layer
                 const firstHiddenLayerX = layerXs[1]; // Index 1 is first hidden layer
                 const lastHiddenLayerX = layerXs[layerXs.length - 2]; // Second-to-last is last hidden layer
                 const centerX = (firstHiddenLayerX + lastHiddenLayerX) / 2;
-                
+
                 // Draw "Layers" label at the calculated center position
                 networkCtx.fillStyle = lblClr;
                 networkCtx.font = lblFnt;
                 networkCtx.textBaseline = "bottom";
                 networkCtx.fillText("Layers", centerX, pad - lblOff / 2);
             }
-            
+
             layerPos.forEach((lNodes, lIdx) => {
                 // Draw Label
                 networkCtx.fillStyle = lblClr; networkCtx.font = lblFnt; networkCtx.textBaseline = "bottom";
@@ -963,9 +1085,15 @@
         window.addEventListener('resize', resizeCanvases); setTimeout(resizeCanvases, 150);
 
         saveButton.addEventListener('click', () => { if (!nn.layers || nn.layers.length === 0) { statsEl.innerHTML = '<span class="error">No model to save.</span>'; return; } nn.save('oblix_model'); statsEl.innerHTML = 'Model saved.'; });
-        loadButton.addEventListener('click', () => { statsEl.innerHTML = 'Loading...'; nn.load((error) => { if (error) { statsEl.innerHTML = `<span class="error">Load failed: ${error.message}</span>`; return; } const params = nn.getTotalParameters(); statsEl.innerHTML = `<strong>Model loaded!</strong> Params: ${params.toLocaleString()}`; try { const d = nn.details?.training; const l = nn.layers || []; usePositionalEncodingCheckbox.checked = nn.usePositionalEncoding || false; if (d) { epochsInput.value=d.epochs||50; learningRateInput.value=d.learningRate||0.01; batchSizeInput.value=d.batchSize||8; optimizerSelect.value=d.optimizer||'adam'; lossFunctionSelect.value=d.lossFunction||'mse'; l2LambdaInput.value=d.l2Lambda||0; decayRateInput.value=d.decayRate||0.9; gradientClipValueInput.value=d.gradientClipValue||0; optimizerSelect.dispatchEvent(new Event('change')); } const numHid = Math.max(0, l.length - 1); numHiddenLayersInput.value = numHid; createLayerConfigUI(numHid); l.slice(0, numHid).forEach((layer, i) => { const setV=(s,v)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e&&v!==undefined)e.value=v;}; const setC=(s,c)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e&&c!==undefined)e.checked=c;}; setV(`select[data-layer-index="${i}"][data-config-type="type"]`, layer.type||'dense'); const ts=hiddenLayersConfigContainer.querySelector(`select[data-layer-index="${i}"][data-config-type="type"]`); if(ts)ts.dispatchEvent(new Event('change',{bubbles:true})); switch(layer.type){ case 'dense': setV(`input[data-layer-index="${i}"][data-config-type="size"]`, layer.outputSize); setV(`select[data-layer-index="${i}"][data-config-type="activation"]`, layer.activation); setC(`input[data-layer-index="${i}"][data-config-type="useBias"]`, layer.useBias); break; case 'attention': setV(`input[data-layer-index="${i}"][data-config-type="numHeads"]`, layer.numHeads); break; case 'dropout': setV(`input[data-layer-index="${i}"][data-config-type="rate"]`, layer.rate); break; } }); lossHistory=[]; drawLossGraph(); predictionResultEl.innerHTML='Result: -'; try { const sample = parseCSV(trainingDataTextarea.value)[0]; if(sample) nn.predict(sample.input); } catch(e) {} drawNetwork(); } catch (uiError) { console.error("UI update err after load:", uiError); statsEl.innerHTML += ` <span class="error">(UI update failed)</span>`; } }); });
+        loadButton.addEventListener('click', () => { statsEl.innerHTML = 'Loading...'; nn.load((error) => { if (error) { statsEl.innerHTML = `<span class="error">Load failed: ${error.message}</span>`; return; } const params = nn.getTotalParameters(); statsEl.innerHTML = `<strong>Model loaded!</strong> Params: ${params.toLocaleString()}`; try { const d = nn.details?.training; const l = nn.layers || []; usePositionalEncodingCheckbox.checked = nn.usePositionalEncoding || false; if (d) { epochsInput.value=d.epochs||50; learningRateInput.value=d.learningRate||0.01; batchSizeInput.value=d.batchSize||8; optimizerSelect.value=d.optimizer||'adam'; lossFunctionSelect.value=d.lossFunction||'mse'; l2LambdaInput.value=d.l2Lambda||0; decayRateInput.value=d.decayRate||0.9; gradientClipValueInput.value=d.gradientClipValue||0; optimizerSelect.dispatchEvent(new Event('change')); } const numHid = Math.max(0, l.length - 1); numHiddenLayersInput.value = numHid; createLayerConfigUI(numHid); l.slice(0, numHid).forEach((layer, i) => { const setV=(s,v)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e&&v!==undefined)e.value=v;}; const setC=(s,c)=>{const e=hiddenLayersConfigContainer.querySelector(s); if(e&&c!==undefined)e.checked=c;}; setV(`select[data-layer-index="${i}"][data-config-type="type"]`, layer.type||'dense'); const ts=hiddenLayersConfigContainer.querySelector(`select[data-layer-index="${i}"][data-config-type="type"]`); if(ts)ts.dispatchEvent(new Event('change',{bubbles:true})); switch(layer.type){ case 'dense': setV(`input[data-layer-index="${i}"][data-config-type="size"]`, layer.outputSize); setV(`select[data-layer-index="${i}"][data-config-type="activation"]`, layer.activation); setC(`input[data-layer-index="${i}"][data-config-type="useBias"]`, layer.useBias); break; case 'attention': setV(`input[data-layer-index="${i}"][data-config-type="numHeads"]`, layer.numHeads); break; case 'dropout': setV(`input[data-layer-index="${i}"][data-config-type="rate"]`, layer.rate); break; } });
+                // {{ Set template dropdown to Custom after load }}
+                architectureTemplateSelect.value = 'custom';
+                lossHistory=[]; drawLossGraph(); predictionResultEl.innerHTML='Result: -'; try { const sample = parseCSV(trainingDataTextarea.value)[0]; if(sample) nn.predict(sample.input); } catch(e) {} drawNetwork(); } catch (uiError) { console.error("UI update err after load:", uiError); statsEl.innerHTML += ` <span class="error">(UI update failed)</span>`; } }); });
         predictButton.addEventListener('click', () => { predictionResultEl.innerHTML=`Predicting...`; try { const inputStr = document.getElementById('predictionInput').value; if(!inputStr)throw new Error("Input empty."); const input=inputStr.split(',').map(s=>parseFloat(s.trim())); if(input.some(isNaN))throw new Error("Invalid input."); if(!nn.layers||nn.layers.length===0)throw new Error("Network not init."); const expectSz=nn.layers[0]?.inputSize; if(expectSz===undefined)throw new Error("Cannot get input size."); if(input.length!==expectSz)throw new Error(`Input size mismatch: Exp ${expectSz}, got ${input.length}.`); const pred=nn.predict(input); if(pred===null)throw new Error("Prediction failed."); const predStr=pred.map(p=>p.toFixed(5)).join(', '); predictionResultEl.innerHTML=`Result: [${predStr}]`; drawNetwork(); } catch (error) { console.error("Predict error:", error); predictionResultEl.innerHTML = `<span class="error">Error: ${error.message}</span>`; } });
-        unloadButton.addEventListener('click', () => { console.log("Unload clicked."); try { nn.reset(); lossHistory = []; drawLossGraph(); drawNetwork(); epochBar.style.width = '0%'; statsEl.innerHTML = 'Status: Model unloaded.'; predictionResultEl.innerHTML = 'Result: -'; const defaultLayers = 2; numHiddenLayersInput.value = defaultLayers; createLayerConfigUI(defaultLayers); console.log("Model & UI reset."); } catch (error) { console.error("Unload error:", error); statsEl.innerHTML = `<span class="error">Unload error: ${error.message}</span>`; } });
+        unloadButton.addEventListener('click', () => { console.log("Unload clicked."); try { nn.reset(); lossHistory = []; drawLossGraph(); drawNetwork(); epochBar.style.width = '0%'; statsEl.innerHTML = 'Status: Model unloaded.'; predictionResultEl.innerHTML = 'Result: -'; const defaultLayers = 2; numHiddenLayersInput.value = defaultLayers; createLayerConfigUI(defaultLayers);
+            // {{ Set template dropdown to Custom after unload/reset }}
+            architectureTemplateSelect.value = 'custom';
+             console.log("Model & UI reset."); } catch (error) { console.error("Unload error:", error); statsEl.innerHTML = `<span class="error">Unload error: ${error.message}</span>`; } });
 
     }); // End DOMContentLoaded
   </script>


### PR DESCRIPTION
Implements a new dropdown menu allowing users to select predefined network architectures ("Simple MLP", "Basic Autoencoder") as a starting point for configuration.

- Adds HTML select element (#architectureTemplateSelect) to UI.
- Defines template configurations in JavaScript (architectureTemplates).
- Implements event listener to update hidden layer count and populate layer settings based on template selection.
- Ensures UI updates complete before populating settings using setTimeout.
- Resets template dropdown to "Custom" when users manually edit layer settings, load a model, or unload the current model.
- Adjusts the final layer configuration logic during training setup to correctly handle autoencoder output size (matching input) and activation.