### PR TITLE
feat: Add Transformer Encoder and Residual Attention templates, updat…

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,8 @@
               <option value="custom" selected>Custom</option>
               <option value="mlp">Simple MLP</option>
               <option value="autoencoder">Basic Autoencoder</option>
+              <option value="transformerEncoder">Transformer Encoder</option>
+              <option value="residual-attention">Residual Attention</option>
               <!-- Add more templates here in the future -->
           </select>
       </div>
@@ -363,22 +365,22 @@
     // --- Namespace for Activation Functions ---
     const oblixActivations = {
         apply: function(x, activation) {
-            const alpha = 0.01; const softplus = (v) => Math.log(1 + Math.exp(v));
-            switch (activation) {
-              case 'tanh': return Math.tanh(x); case 'sigmoid': return 1 / (1 + Math.exp(-x)); case 'relu': return Math.max(0, x); case 'leakyrelu': return x > 0 ? x : alpha * x; case 'gelu': return 0.5 * x * (1 + Math.tanh(Math.sqrt(2 / Math.PI) * (x + 0.044715 * x**3))); case 'selu': const sa = 1.67326, ss=1.0507; return x > 0 ? ss * x : ss * sa * (Math.exp(x) - 1);
-              case 'swish': return x / (1 + Math.exp(-x)); case 'mish': return x * Math.tanh(softplus(x));
-              case 'softmax': case 'none': default: return x;
-            }
+        const alpha = 0.01; const softplus = (v) => Math.log(1 + Math.exp(v));
+        switch (activation) {
+          case 'tanh': return Math.tanh(x); case 'sigmoid': return 1 / (1 + Math.exp(-x)); case 'relu': return Math.max(0, x); case 'leakyrelu': return x > 0 ? x : alpha * x; case 'gelu': return 0.5 * x * (1 + Math.tanh(Math.sqrt(2 / Math.PI) * (x + 0.044715 * x**3))); case 'selu': const sa = 1.67326, ss=1.0507; return x > 0 ? ss * x : ss * sa * (Math.exp(x) - 1);
+          case 'swish': return x / (1 + Math.exp(-x)); case 'mish': return x * Math.tanh(softplus(x));
+          case 'softmax': case 'none': default: return x;
+        }
         },
         derivative: function(x, activation) {
-            const alpha = 0.01; let val; const sigmoid = (v) => 1 / (1 + Math.exp(-v)); const softplus = (v) => Math.log(1 + Math.exp(v)); const dtanh_dx = (v) => 1 - Math.tanh(v)**2;
-            switch (activation) {
-                case 'tanh': val = Math.tanh(x); return 1 - val * val; case 'sigmoid': val = sigmoid(x); return val * (1 - val); case 'relu': return x > 0 ? 1 : 0; case 'leakyrelu': return x > 0 ? 1 : alpha; case 'gelu': const k=Math.sqrt(2 / Math.PI), inner=k*(x+0.044715*x**3), tanh_inner=Math.tanh(inner), d_inner_dx=k*(1+0.134145*x**2), sech_sq_inner=1-tanh_inner**2; return 0.5*(1+tanh_inner)+0.5*x*sech_sq_inner*d_inner_dx; case 'selu': const sa=1.67326, ss=1.0507; return x > 0 ? ss : ss * sa * Math.exp(x);
-                case 'swish': const sig_x = sigmoid(x); return sig_x + x * sig_x * (1 - sig_x);
-                case 'mish': const sp_x = softplus(x); const tanh_sp_x = Math.tanh(sp_x); const dsp_dx = sigmoid(x); const dtanh_dsp = dtanh_dx(sp_x); return tanh_sp_x + x * dtanh_dsp * dsp_dx;
-                case 'softmax': case 'none': default: return 1;
-            }
-        }
+          const alpha = 0.01; let val; const sigmoid = (v) => 1 / (1 + Math.exp(-v)); const softplus = (v) => Math.log(1 + Math.exp(v)); const dtanh_dx = (v) => 1 - Math.tanh(v)**2;
+          switch (activation) {
+              case 'tanh': val = Math.tanh(x); return 1 - val * val; case 'sigmoid': val = sigmoid(x); return val * (1 - val); case 'relu': return x > 0 ? 1 : 0; case 'leakyrelu': return x > 0 ? 1 : alpha; case 'gelu': const k=Math.sqrt(2 / Math.PI), inner=k*(x+0.044715*x**3), tanh_inner=Math.tanh(inner), d_inner_dx=k*(1+0.134145*x**2), sech_sq_inner=1-tanh_inner**2; return 0.5*(1+tanh_inner)+0.5*x*sech_sq_inner*d_inner_dx; case 'selu': const sa=1.67326, ss=1.0507; return x > 0 ? ss : ss * sa * Math.exp(x);
+              case 'swish': const sig_x = sigmoid(x); return sig_x + x * sig_x * (1 - sig_x);
+              case 'mish': const sp_x = softplus(x); const tanh_sp_x = Math.tanh(sp_x); const dsp_dx = sigmoid(x); const dtanh_dsp = dtanh_dx(sp_x); return tanh_sp_x + x * dtanh_dsp * dsp_dx;
+              case 'softmax': case 'none': default: return 1;
+          }
+      }
     };
     // --- End Namespace ---
 
@@ -478,7 +480,7 @@
                 l2Lambda,
                 gradientClipValue,
                 decayRate // For RMSProp, passed from context
-            } = options;
+        } = options;
 
             const batchMult = 1.0 / batchSize;
             context.t++; // Increment global timestep
@@ -494,22 +496,22 @@
                 let adamCorrectedBaseLR = initialLearningRate * Math.sqrt(1 - context.beta2 ** context.t) / (1 - context.beta1 ** context.t);
                 let adamStepLR = adamCorrectedBaseLR * (learningRate / initialLearningRate); // Apply schedule scaling
 
-                // --- Weight Updates (Dense Layers) ---
+              // --- Weight Updates (Dense Layers) ---
                 if (isDense && Array.isArray(context.weights[i]) && Array.isArray(gradsW[i])) {
                     const w = context.weights[i]; const gW = gradsW[i];
-                    for (let j = 0; j < cfg.outputSize; j++) {
-                        for (let k = 0; k < cfg.inputSize; k++) {
-                            if (typeof w[j]?.[k] !== 'number' || typeof gW[j]?.[k] !== 'number') continue;
-                            const grad = gW[j][k] * batchMult;
-                            let param = w[j][k];
+                for (let j = 0; j < cfg.outputSize; j++) {
+                  for (let k = 0; k < cfg.inputSize; k++) {
+                    if (typeof w[j]?.[k] !== 'number' || typeof gW[j]?.[k] !== 'number') continue;
+                    const grad = gW[j][k] * batchMult;
+                    let param = w[j][k];
                             let m = context.m_dw?.[i]?.[j]?.[k];
                             let v = context.v_dw?.[i]?.[j]?.[k];
                             let s = context.s_dw?.[i]?.[j]?.[k];
-                            let update = 0;
+                    let update = 0;
 
-                            const clippedGrad = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, grad)) : grad;
+                    const clippedGrad = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, grad)) : grad;
 
-                            if (optimizer === 'adam' || optimizer === 'adamw') {
+                    if (optimizer === 'adam' || optimizer === 'adamw') {
                                 m = (typeof m === 'number' && isFinite(m)) ? m : 0; v = (typeof v === 'number' && isFinite(v)) ? v : 0;
                                 m = context.beta1 * m + (1 - context.beta1) * clippedGrad;
                                 v = context.beta2 * v + (1 - context.beta2) * clippedGrad ** 2;
@@ -518,109 +520,109 @@
                                 update = adamStepLR * m_hat / (Math.sqrt(v_hat) + context.epsilon);
                                 if (optimizer === 'adam' && l2Lambda > 0) { update += adamStepLR * l2Lambda * param; }
                                 if (context.m_dw?.[i]?.[j]) context.m_dw[i][j][k] = m; if (context.v_dw?.[i]?.[j]) context.v_dw[i][j][k] = v;
-                            } else if (optimizer === 'rmsprop') {
-                                s = (typeof s === 'number' && isFinite(s)) ? s : 0;
+                    } else if (optimizer === 'rmsprop') {
+                      s = (typeof s === 'number' && isFinite(s)) ? s : 0;
                                 s = decayRate * s + (1 - decayRate) * clippedGrad ** 2; // Use context's decayRate
                                 update = stepLR * clippedGrad / (Math.sqrt(s) + context.epsilon);
                                 if (l2Lambda > 0) { update += stepLR * l2Lambda * param; }
                                 if (context.s_dw?.[i]?.[j]) context.s_dw[i][j][k] = s;
-                            } else { // SGD
-                                update = stepLR * clippedGrad;
+                    } else { // SGD
+                      update = stepLR * clippedGrad;
                                 if (l2Lambda > 0) { update += stepLR * l2Lambda * param; }
                             }
                             param -= update;
                             if (optimizer === 'adamw' && l2Lambda > 0) { param -= adamStepLR * l2Lambda * param; } // Decoupled decay
                             context.weights[i][j][k] = param; // Update weight in context
                         }
-                    }
                 }
+              }
 
-                // --- Bias Updates (Dense Layers) ---
+              // --- Bias Updates (Dense Layers) ---
                 if (isDense && cfg.useBias && Array.isArray(context.biases[i]) && Array.isArray(gradsB[i])) {
                     const b = context.biases[i]; const gB = gradsB[i];
-                    for (let j = 0; j < cfg.outputSize; j++) {
-                        if (typeof b[j] !== 'number' || typeof gB[j] !== 'number') continue;
-                        const grad = gB[j] * batchMult;
-                        let param = b[j];
+                for (let j = 0; j < cfg.outputSize; j++) {
+                    if (typeof b[j] !== 'number' || typeof gB[j] !== 'number') continue;
+                    const grad = gB[j] * batchMult;
+                    let param = b[j];
                         let m = context.m_db?.[i]?.[j]; let v = context.v_db?.[i]?.[j]; let s = context.s_db?.[i]?.[j];
-                        let update = 0;
-                        const clippedGrad = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, grad)) : grad;
+                    let update = 0;
+                    const clippedGrad = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, grad)) : grad;
 
-                        if (optimizer === 'adam' || optimizer === 'adamw') {
+                    if (optimizer === 'adam' || optimizer === 'adamw') {
                             m = (typeof m === 'number' && isFinite(m)) ? m : 0; v = (typeof v === 'number' && isFinite(v)) ? v : 0;
                             m = context.beta1 * m + (1 - context.beta1) * clippedGrad; v = context.beta2 * v + (1 - context.beta2) * clippedGrad ** 2;
                             const m_hat = m / (1 - context.beta1 ** context.t); const v_hat = v / (1 - context.beta2 ** context.t);
                             update = adamStepLR * m_hat / (Math.sqrt(v_hat) + context.epsilon);
                             if (context.m_db?.[i]) context.m_db[i][j] = m; if (context.v_db?.[i]) context.v_db[i][j] = v;
-                        } else if (optimizer === 'rmsprop') {
-                            s = (typeof s === 'number' && isFinite(s)) ? s : 0;
+                    } else if (optimizer === 'rmsprop') {
+                      s = (typeof s === 'number' && isFinite(s)) ? s : 0;
                             s = decayRate * s + (1 - decayRate) * clippedGrad ** 2;
                             update = stepLR * clippedGrad / (Math.sqrt(s) + context.epsilon);
                             if (context.s_db?.[i]) context.s_db[i][j] = s;
-                        } else { // SGD
-                            update = stepLR * clippedGrad;
-                        }
-                        param -= update;
-                        context.biases[i][j] = param; // Update bias in context
+                    } else { // SGD
+                      update = stepLR * clippedGrad;
                     }
+                    param -= update;
+                        context.biases[i][j] = param; // Update bias in context
                 }
+              }
 
-                // --- LayerNorm Parameter Updates (Gamma & Beta) ---
+              // --- LayerNorm Parameter Updates (Gamma & Beta) ---
                 if (isLN && Array.isArray(context.gammas[i]) && Array.isArray(context.betas[i]) && Array.isArray(gradsGamma[i]) && Array.isArray(gradsBeta[i])) {
                     const g = context.gammas[i]; const betaParam = context.betas[i];
                     const gGamma = gradsGamma[i]; const gBeta = gradsBeta[i];
-                    for (let j = 0; j < cfg.outputSize; j++) {
-                        // Update Gamma
-                        if (typeof g[j] === 'number' && typeof gGamma[j] === 'number') {
+                for (let j = 0; j < cfg.outputSize; j++) {
+                  // Update Gamma
+                  if (typeof g[j] === 'number' && typeof gGamma[j] === 'number') {
                             const gradGamma = gGamma[j] * batchMult; let paramGamma = g[j];
                             let mGamma = context.m_dgamma?.[i]?.[j]; let vGamma = context.v_dgamma?.[i]?.[j]; let sGamma = context.s_dgamma?.[i]?.[j];
-                            let updateGamma = 0;
-                            const clippedGradGamma = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, gradGamma)) : gradGamma;
+                    let updateGamma = 0;
+                    const clippedGradGamma = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, gradGamma)) : gradGamma;
 
-                            if (optimizer === 'adam' || optimizer === 'adamw') {
+                    if (optimizer === 'adam' || optimizer === 'adamw') {
                                 mGamma = (typeof mGamma === 'number' && isFinite(mGamma)) ? mGamma : 0; vGamma = (typeof vGamma === 'number' && isFinite(vGamma)) ? vGamma : 0;
                                 mGamma = context.beta1 * mGamma + (1 - context.beta1) * clippedGradGamma; vGamma = context.beta2 * vGamma + (1 - context.beta2) * clippedGradGamma ** 2;
                                 const m_hat = mGamma / (1 - context.beta1 ** context.t); const v_hat = vGamma / (1 - context.beta2 ** context.t);
                                 updateGamma = adamStepLR * m_hat / (Math.sqrt(v_hat) + context.epsilon);
                                 if (context.m_dgamma?.[i]) context.m_dgamma[i][j] = mGamma; if (context.v_dgamma?.[i]) context.v_dgamma[i][j] = vGamma;
-                            } else if (optimizer === 'rmsprop') {
-                                sGamma = (typeof sGamma === 'number' && isFinite(sGamma)) ? sGamma : 0;
+                    } else if (optimizer === 'rmsprop') {
+                       sGamma = (typeof sGamma === 'number' && isFinite(sGamma)) ? sGamma : 0;
                                 sGamma = decayRate * sGamma + (1 - decayRate) * clippedGradGamma ** 2;
                                 updateGamma = stepLR * clippedGradGamma / (Math.sqrt(sGamma) + context.epsilon);
                                 if (context.s_dgamma?.[i]) context.s_dgamma[i][j] = sGamma;
-                            } else { // SGD
-                                updateGamma = stepLR * clippedGradGamma;
-                            }
-                            paramGamma -= updateGamma;
+                    } else { // SGD
+                       updateGamma = stepLR * clippedGradGamma;
+                    }
+                    paramGamma -= updateGamma;
                             context.gammas[i][j] = paramGamma; // Update gamma in context
-                        }
+                  }
 
-                        // Update Beta
-                        if (typeof betaParam[j] === 'number' && typeof gBeta[j] === 'number') {
+                  // Update Beta
+                  if (typeof betaParam[j] === 'number' && typeof gBeta[j] === 'number') {
                             const gradBeta = gBeta[j] * batchMult; let paramBeta = betaParam[j];
                             let mBeta = context.m_dbeta?.[i]?.[j]; let vBeta = context.v_dbeta?.[i]?.[j]; let sBeta = context.s_dbeta?.[i]?.[j];
-                            let updateBeta = 0;
-                            const clippedGradBeta = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, gradBeta)) : gradBeta;
+                    let updateBeta = 0;
+                    const clippedGradBeta = gradientClipValue > 0 ? Math.max(-gradientClipValue, Math.min(gradientClipValue, gradBeta)) : gradBeta;
 
-                             if (optimizer === 'adam' || optimizer === 'adamw') {
+                    if (optimizer === 'adam' || optimizer === 'adamw') {
                                 mBeta = (typeof mBeta === 'number' && isFinite(mBeta)) ? mBeta : 0; vBeta = (typeof vBeta === 'number' && isFinite(vBeta)) ? vBeta : 0;
                                 mBeta = context.beta1 * mBeta + (1 - context.beta1) * clippedGradBeta; vBeta = context.beta2 * vBeta + (1 - context.beta2) * clippedGradBeta ** 2;
                                 const m_hat = mBeta / (1 - context.beta1 ** context.t); const v_hat = vBeta / (1 - context.beta2 ** context.t);
                                 updateBeta = adamStepLR * m_hat / (Math.sqrt(v_hat) + context.epsilon);
                                 if (context.m_dbeta?.[i]) context.m_dbeta[i][j] = mBeta; if (context.v_dbeta?.[i]) context.v_dbeta[i][j] = vBeta;
-                            } else if (optimizer === 'rmsprop') {
-                                sBeta = (typeof sBeta === 'number' && isFinite(sBeta)) ? sBeta : 0;
+                    } else if (optimizer === 'rmsprop') {
+                       sBeta = (typeof sBeta === 'number' && isFinite(sBeta)) ? sBeta : 0;
                                 sBeta = decayRate * sBeta + (1 - decayRate) * clippedGradBeta ** 2;
                                 updateBeta = stepLR * clippedGradBeta / (Math.sqrt(sBeta) + context.epsilon);
                                 if (context.s_dbeta?.[i]) context.s_dbeta[i][j] = sBeta;
-                            } else { // SGD
-                                updateBeta = stepLR * clippedGradBeta;
-                            }
-                            paramBeta -= updateBeta;
-                            context.betas[i][j] = paramBeta; // Update beta in context
-                        }
+                    } else { // SGD
+                       updateBeta = stepLR * clippedGradBeta;
                     }
+                    paramBeta -= updateBeta;
+                            context.betas[i][j] = paramBeta; // Update beta in context
+                  }
                 }
+              }
             } // End param update layer loop
         }
     };
@@ -630,7 +632,98 @@
     const oblixUtils = {
         positionalEncoding: function(input, maxLen = -1) {
             const dModel=input.length; if(dModel===0) return []; if(maxLen<0) maxLen=dModel; const pe=new Array(dModel).fill(0); for(let i=0;i<dModel;i++){ const divTermBase=Math.pow(10000,Math.floor(i/2)*2/dModel); if(divTermBase===0) continue; const angle=i/divTermBase; pe[i]=(i%2===0)?Math.sin(angle):Math.cos(angle); } return input.map((val,i)=>val+pe[i]);
+        },
+
+        /**
+         * Calculates accuracy for classification tasks.
+         * Assumes predictions are probability distributions (e.g., from Softmax)
+         * and targets are either class indices or one-hot encoded vectors.
+         * @param {number[][]} predictions - Array of prediction vectors.
+         * @param {(number[]|number[][])} targets - Array of target class indices or one-hot vectors.
+         * @returns {number} Accuracy value (0.0 to 1.0).
+         */
+        calculateAccuracy: function(predictions, targets) {
+            if (!predictions || !targets || predictions.length === 0 || predictions.length !== targets.length) {
+                console.warn("Accuracy calculation: Invalid input arrays.");
+                return 0.0;
+            }
+
+            let correct = 0;
+            for (let i = 0; i < predictions.length; i++) {
+                const predVec = predictions[i];
+                const targetInfo = targets[i];
+
+                if (!predVec || !targetInfo) continue; // Skip invalid entries
+
+                // Find the index of the highest probability in the prediction
+                const predictedIndex = predVec.indexOf(Math.max(...predVec));
+
+                let targetIndex = -1;
+                // Check if target is a class index (single number)
+                if (typeof targetInfo === 'number' && Number.isInteger(targetInfo)) {
+                    targetIndex = targetInfo;
+                }
+                // Check if target is a one-hot vector
+                else if (Array.isArray(targetInfo) && targetInfo.length === predVec.length) {
+                    targetIndex = targetInfo.indexOf(1);
+                    // Handle cases where it's not strictly one-hot (e.g., [0.9, 0.1]) - find max
+                    if (targetIndex === -1) {
+                       targetIndex = targetInfo.indexOf(Math.max(...targetInfo));
+                    }
+                } else {
+                     console.warn(`Accuracy calc: Invalid target format at index ${i}`, targetInfo);
+                     continue;
+                }
+
+
+                if (predictedIndex === targetIndex && targetIndex !== -1) {
+                    correct++;
+                }
+            }
+            return predictions.length > 0 ? correct / predictions.length : 0.0;
+        },
+
+        /**
+         * Calculates the R-squared (Coefficient of Determination) for regression tasks.
+         * @param {number[]} predictions - Array of predicted values.
+         * @param {number[]} targets - Array of true target values.
+         * @returns {number} R-squared value. Can be negative for poor models.
+         */
+        calculateRSquared: function(predictions, targets) {
+            if (!predictions || !targets || predictions.length === 0 || predictions.length !== targets.length) {
+                console.warn("R-squared calculation: Invalid input arrays.");
+                return NaN; // Indicate invalid input
+            }
+             if (predictions.length < 2) {
+                 console.warn("R-squared calculation: Need at least 2 data points.");
+                 return NaN; // R-squared is ill-defined for n < 2
+             }
+
+            const targetMean = targets.reduce((sum, val) => sum + val, 0) / targets.length;
+
+            let ssTot = 0; // Total sum of squares
+            let ssRes = 0; // Residual sum of squares
+
+            for (let i = 0; i < targets.length; i++) {
+                const targetVal = targets[i];
+                const predVal = predictions[i];
+                if (typeof targetVal !== 'number' || typeof predVal !== 'number' || !isFinite(targetVal) || !isFinite(predVal)) {
+                     console.warn(`R-squared calc: Non-finite number at index ${i}`);
+                     return NaN; // Invalid data point
+                }
+                ssTot += (targetVal - targetMean) ** 2;
+                ssRes += (targetVal - predVal) ** 2;
+            }
+
+            if (ssTot === 0) {
+                // If all targets are the same, R-squared is undefined or sometimes treated as 1 if predictions are also perfect, 0 otherwise.
+                // Returning NaN or 0 depends on convention. Let's return NaN for undefined case.
+                return (ssRes === 0) ? 1.0 : NaN; // Perfect prediction if ssRes is also 0, otherwise undefined
+            }
+
+            return 1 - (ssRes / ssTot);
         }
+
         // Add other utils here later if needed
     };
     // --- End Utility Namespace ---
@@ -716,6 +809,9 @@
         if (!trainSet || trainSet.length === 0) throw new Error("Training set empty."); if (this.layers.length === 0) throw new Error("No layers."); const effectiveBatchSize = Math.max(1, Math.min(batchSize, trainSet.length)); this.usePositionalEncoding = usePositionalEncoding; this.decayRate = decayRate;
         let needsOptimizerInit = this.m_dw?.length !== this.layers.length || this.v_dw?.length !== this.layers.length || this.s_dw?.length !== this.layers.length || this.m_db?.length !== this.layers.length || this.v_db?.length !== this.layers.length || this.s_db?.length !== this.layers.length; for (let i=0; i < this.layers.length && !needsOptimizerInit; i++) { if (this.layers[i].type === 'dense') { if (this.weights[i] && this.m_dw[i] === null) needsOptimizerInit = true; if (this.biases[i] && this.m_db[i] === null) needsOptimizerInit = true; } else if (this.layers[i].type === 'layernorm') { if (this.gammas[i] && this.m_dgamma[i] === null) needsOptimizerInit = true; if (this.betas[i] && this.m_dbeta[i] === null) needsOptimizerInit = true; } } if (needsOptimizerInit) { if (this.debug) console.log("Optimizer state needs init."); this.initializeOptimizerState(optimizer); }
         let lastTrainLoss = Infinity; let lastTestLoss = null;
+        // {{ Add: Variable for the validation metric }}
+        let lastValidationMetric = null;
+        let validationMetricName = ''; // e.g., "Acc" or "R²"
 
         for (let epoch = 0; epoch < epochs; epoch++) {
           // ++ Calculate Learning Rate for the Current Epoch ++
@@ -757,17 +853,120 @@
           } // End batch loop
 
           lastTrainLoss = totalEpochTrainError / trainSet.length;
-          if (testSet && testSet.length > 0) { let testError = 0; for (const data of testSet) { const prediction = this.predict(data.input); if (prediction && prediction.length === data.output.length) { const target = data.output; let sampleLoss = 0; if (lossFunction === 'crossentropy') { const lastLayer = this.layers[this.layers.length-1]; const wasSoftmax = lastLayer.type === 'softmax' || (lastLayer.type === 'dense' && lastLayer.activation === 'softmax'); const wasSigmoid = lastLayer.type === 'dense' && lastLayer.activation === 'sigmoid'; if (wasSoftmax) { if (target.length === 1 && Number.isInteger(target[0])) { sampleLoss = -Math.log(prediction[target[0]] + eps_ce); } else { sampleLoss = -target.reduce((sum, t, i) => sum + t * Math.log(prediction[i] + eps_ce), 0); } } else if (wasSigmoid && prediction.length === 1) { sampleLoss = - (target[0] * Math.log(prediction[0] + eps_ce) + (1 - target[0]) * Math.log(1 - prediction[0] + eps_ce)); } else { sampleLoss = 0.5 * prediction.reduce((sum, p, i) => sum + (p - target[i])**2, 0); } } else { sampleLoss = 0.5 * prediction.reduce((sum, p, i) => sum + (p - target[i])**2, 0); } if (!isNaN(sampleLoss) && isFinite(sampleLoss)) testError += sampleLoss; } } lastTestLoss = testError / testSet.length; } else { lastTestLoss = null; }
-          if ((epoch + 1) % printEveryEpochs === 0 && this.debug) { const lrStr = lrSchedule !== 'none' ? `, LR: ${currentEpochLearningRate.toExponential(2)}` : ''; console.log(`Epoch ${epoch + 1}/${epochs}, Train Loss: ${lastTrainLoss.toFixed(6)}${lastTestLoss !== null ? `, Val Loss: ${lastTestLoss.toFixed(6)}` : ''}${lrStr}`); }
-          if (callback) { await callback(epoch + 1, lastTrainLoss, lastTestLoss); }
-          await new Promise(resolve => setTimeout(resolve, 0));
-          if (lastTrainLoss < earlyStopThreshold) { if (this.debug) console.log(`Early stopping @ Epoch ${epoch + 1}.`); epochs = epoch + 1; break; }
+
+          // --- Validation Step ---
+          if (testSet && testSet.length > 0) {
+              let testError = 0;
+              const allValPredictions = [];
+              const allValTargets = [];
+
+              for (const data of testSet) {
+                  const prediction = this.predict(data.input);
+                  if (prediction && data.output && prediction.length === data.output.length) {
+                      const target = data.output;
+                      allValPredictions.push(prediction);
+                      allValTargets.push(target);
+
+                      // --- Calculate Loss (Explicitly include CE loss) ---
+                      let sampleLoss = 0;
+                      const eps_ce = 1e-9;
+                      if (lossFunction === 'crossentropy') {
+                          // {{ Add: Explicit Cross-Entropy sample loss calculation }}
+                          const lastLayer = this.layers[this.layers.length-1];
+                          const wasSoftmax = lastLayer.type === 'softmax' || (lastLayer.type === 'dense' && lastLayer.activation === 'softmax');
+                          const wasSigmoid = lastLayer.type === 'dense' && lastLayer.activation === 'sigmoid';
+
+                          if (wasSoftmax) {
+                              // Handle one-hot or index targets
+                              if (target.length === 1 && Number.isInteger(target[0]) && target[0] >= 0 && target[0] < prediction.length) {
+                                  // Target is a class index
+                                  sampleLoss = -Math.log(prediction[target[0]] + eps_ce);
+                              } else if (target.length === prediction.length) {
+                                   // Target is likely a probability distribution/one-hot vector
+                                  sampleLoss = -target.reduce((sum, t, i) => sum + t * Math.log(prediction[i] + eps_ce), 0);
+                              } else {
+                                  console.warn("CE Val Loss: Target/Prediction shape mismatch for Softmax.");
+                                  sampleLoss = NaN; // Cannot calculate
+                              }
+                          } else if (wasSigmoid && prediction.length === 1 && target.length === 1) {
+                              // Binary Cross-Entropy
+                              const p = prediction[0]; const t = target[0];
+                              sampleLoss = - (t * Math.log(p + eps_ce) + (1 - t) * Math.log(1 - p + eps_ce));
+                          } else {
+                              // Fallback if CE is selected but final layer isn't appropriate
+                              console.warn("CE Val Loss: Final layer activation not Softmax/Sigmoid. Using MSE for loss metric.");
+                              sampleLoss = 0.5 * prediction.reduce((sum, p, i) => sum + (p - target[i])**2, 0);
+                          }
+                      } else { // Default to MSE
+                          sampleLoss = 0.5 * prediction.reduce((sum, p, i) => sum + (p - target[i])**2, 0);
+                      }
+                      // {{ End Add }}
+
+                      if (!isNaN(sampleLoss) && isFinite(sampleLoss)) {
+                          testError += sampleLoss;
+                      }
+                  }
+              }
+              lastTestLoss = testError / testSet.length; // Average loss over validation set
+
+              // --- Calculate Accuracy or R-squared ---
+              if (lossFunction === 'crossentropy') {
+                  validationMetricName = 'Acc';
+                  // Targets might be [[0], [1], [0]] or [0, 1, 0]
+                  // Accuracy function handles both index and one-hot vector targets
+                  lastValidationMetric = oblixUtils.calculateAccuracy(allValPredictions, allValTargets);
+              } else { // Default to R-squared for MSE / other regression tasks
+                  validationMetricName = 'R²';
+                  // R-squared expects flat arrays of numbers
+                  // Flatten predictions/targets if they are multi-dimensional (e.g., [[0.1], [0.9]])
+                  const flatPreds = allValPredictions.flat();
+                  const flatTargets = allValTargets.flat();
+                  lastValidationMetric = oblixUtils.calculateRSquared(flatPreds, flatTargets);
+              }
+
+          } else {
+              lastTestLoss = null;
+              lastValidationMetric = null; // No validation set, no metric
+              validationMetricName = '';
+          }
+          // --- End Validation Step ---
+
+          if ((epoch + 1) % printEveryEpochs === 0 && this.debug) {
+              const lrStr = lrSchedule !== 'none' ? `, LR: ${currentEpochLearningRate.toExponential(2)}` : '';
+              let logMsg = `Epoch ${epoch + 1}/${epochs}, Train Loss: ${lastTrainLoss.toFixed(6)}`;
+              if (lastTestLoss !== null) {
+                   logMsg += `, Val Loss: ${lastTestLoss.toFixed(6)}`;
+              }
+              // {{ Add: Log metric if calculated }}
+              if (lastValidationMetric !== null && !isNaN(lastValidationMetric)) {
+                  logMsg += `, Val ${validationMetricName}: ${lastValidationMetric.toFixed(4)}`;
+              }
+               logMsg += lrStr;
+               console.log(logMsg);
+          }
+
+          // {{ Edit: Pass metric name and value to callback }}
+          if (callback) {
+              await callback(epoch + 1, lastTrainLoss, lastTestLoss, validationMetricName, lastValidationMetric);
+          }
+
+          await new Promise(resolve => setTimeout(resolve, 0)); // Yield to browser
+          if (lastTrainLoss < earlyStopThreshold) {
+              if (this.debug) console.log(`Early stopping @ Epoch ${epoch + 1}.`);
+              epochs = epoch + 1; // Adjust total epochs for summary
+              break;
+          }
         } // End epoch loop
 
         const end = Date.now(); this.isTraining = false;
         const totalParams = this.getTotalParameters();
+
+        // {{ Edit: Add validation metric to summary }}
         const trainingSummary = {
-            trainLoss: lastTrainLoss, testLoss: lastTestLoss, parameters: totalParams,
+            trainLoss: lastTrainLoss,
+            testLoss: lastTestLoss,
+            validationMetric: { name: validationMetricName, value: lastValidationMetric },
+            parameters: totalParams,
             training: {
                 time: end - start, epochs: epochs,
                 learningRate: initialLearningRate, // Report initial LR
@@ -781,7 +980,8 @@
             },
             layers: this.layers.map(l => ({ type: l.type, inputSize: l.inputSize, outputSize: l.outputSize, activation: l.activation, numHeads: l.numHeads, useBias: l.useBias, rate: l.rate }))
         };
-        this.details = trainingSummary; if (this.debug) console.log("Training finished.", trainingSummary);
+        this.details = trainingSummary;
+        if (this.debug) console.log("Training finished.", trainingSummary);
         return trainingSummary;
       }
 
@@ -827,6 +1027,34 @@
                 ],
                 // Special hint for final layer config during training
                 finalActivationHint: 'sigmoid' // Suggest sigmoid if inputs are 0-1, or 'none' otherwise
+            },
+            'transformerEncoder': {
+                numHidden: 8,
+                layers: [
+                    // First: Multi-head attention with layer norm
+                    { type: 'layernorm', size: null },  // Pre-norm architecture
+                    { type: 'attention', numHeads: 3 },
+                    { type: 'dense', size: 32, activation: 'relu', useBias: true }, // FFN part 1
+                    { type: 'dropout', rate: 0.1 },  // Regularization
+                    // Second attention block
+                    { type: 'layernorm', size: null },
+                    { type: 'attention', numHeads: 4 },
+                    { type: 'dense', size: 32, activation: 'relu', useBias: true },
+                    { type: 'dropout', rate: 0.1 }
+                ],
+                // Hint for final layer based on task
+                finalActivationHint: 'none'  // Default to linear output
+            },
+            'residual-attention': {
+                numHidden: 5,
+                layers: [
+                    { type: 'layernorm' },
+                    { type: 'attention', numHeads: 3 },
+                    { type: 'dense', size: 32, activation: 'relu', useBias: true },
+                    { type: 'dropout', rate: 0.1 },
+                    { type: 'layernorm' }
+                ],
+                finalActivationHint: 'none'
             }
             // Add more templates here
         };
@@ -933,18 +1161,41 @@
                 for (let i = 0; i < numHidden; i++) { const getV=(s)=>hiddenLayersConfigContainer.querySelector(s)?.value; const getC=(s)=>hiddenLayersConfigContainer.querySelector(s)?.checked; const lType=getV(`select[data-layer-index="${i}"][data-config-type="type"]`) || 'dense'; let cfg={type:lType, inputSize:curInSize}; switch(lType){ case 'dense': cfg.outputSize=parseInt(getV(`input[data-layer-index="${i}"][data-config-type="size"]`)||1); if(cfg.outputSize<=0) throw new Error(`L${i+1} Dense: Invalid nodes.`); cfg.activation=getV(`select[data-layer-index="${i}"][data-config-type="activation"]`) || 'tanh'; cfg.useBias=getC(`input[data-layer-index="${i}"][data-config-type="useBias"]`)??true; break; case 'attention': cfg.numHeads=parseInt(getV(`input[data-layer-index="${i}"][data-config-type="numHeads"]`)||1); if(cfg.numHeads<=0) throw new Error(`L${i+1} Attn: Invalid heads.`); if(curInSize%cfg.numHeads!==0) throw new Error(`L${i+1} Attn: Input ${curInSize} not divisible by ${cfg.numHeads} heads.`); cfg.outputSize=curInSize; break; case 'dropout': cfg.rate=parseFloat(getV(`input[data-layer-index="${i}"][data-config-type="rate"]`)||0); if(cfg.rate<0||cfg.rate>=1) throw new Error(`L${i+1} Dropout: Invalid rate.`); cfg.outputSize=curInSize; break; case 'layernorm': case 'softmax': cfg.outputSize=curInSize; break; default: throw new Error(`L${i+1}: Unknown type "${lType}".`); } if(!cfg.outputSize) throw new Error(`L${i+1}: No output size.`); layerCfgs.push(cfg); curInSize=cfg.outputSize; }
                 // {{ Adjust final layer based on template and data }}
                 const isAutoencoder = architectureTemplateSelect.value === 'autoencoder';
-                const numOuts = isAutoencoder ? numIns : trainingData[0].output.length; // Autoencoder output size matches input size
+                const numOuts = isAutoencoder ? numIns : trainingData[0].output.length;
                 if(numOuts <= 0) throw new Error("Zero output cols defined.");
 
-                const finalNeedsSoftmax = !isAutoencoder && lossFunctionSelect.value === 'crossentropy' && numOuts > 1;
-                let finalAct = 'tanh'; // Default final activation
-                if (finalNeedsSoftmax) {
-                    finalAct = 'softmax';
-                } else if (isAutoencoder) {
-                    // Use hint from template, default to sigmoid/none based on complexity
+                const selectedLoss = lossFunctionSelect.value; // Get selected loss function
+
+                // {{ Edit: Refined final activation logic }}
+                let finalAct = 'none'; // Default to linear activation ('none') for regression (MSE)
+
+                if (selectedLoss === 'crossentropy') {
+                    if (isAutoencoder) {
+                         // Autoencoders typically reconstruct input, often using sigmoid/tanh depending on input range
                     finalAct = architectureTemplates['autoencoder']?.finalActivationHint || 'sigmoid';
-                    console.log(`Autoencoder detected, using final activation: ${finalAct}`);
+                         console.log(`Autoencoder with Cross-Entropy? Using template hint or sigmoid: ${finalAct}`);
+                         // Note: Using CE loss with autoencoders is less common than MSE unless inputs are treated as probabilities.
+                    } else if (numOuts > 1) {
+                         // Multi-class classification
+                         finalAct = 'softmax';
+                    } else if (numOuts === 1) {
+                         // Binary classification
+                         finalAct = 'sigmoid';
+                    }
+                } else if (selectedLoss === 'mse') {
+                     if (isAutoencoder) {
+                         // Autoencoders with MSE often use sigmoid/tanh if input is bounded, or none otherwise
+                         finalAct = architectureTemplates['autoencoder']?.finalActivationHint || 'sigmoid'; // Keep sigmoid/tanh hint possibility
+                         console.log(`Autoencoder with MSE, using template hint or sigmoid: ${finalAct}`);
+                     } else {
+                         // Standard regression - default is already 'none'
+                         // If target values are known to be bounded (e.g., 0-1 or -1 to 1),
+                         // tanh or sigmoid *might* be appropriate, but 'none' is safer general default.
+                         finalAct = 'none';
+                         console.log('MSE loss selected, using linear final activation: none');
+                     }
                 }
+                // If a different loss function were added later, it would default to 'none' here.
 
                 console.log(`Adding final dense: ${curInSize}->${numOuts} (Act:${finalAct})`);
                 layerCfgs.push({type:'dense', inputSize:curInSize, outputSize:numOuts, activation:finalAct, useBias:true});
@@ -966,15 +1217,26 @@
                     lrStepDecayFactor: parseFloat(document.getElementById('lrStepDecayFactor').value) || 0.1,
                     lrStepDecaySize: parseInt(document.getElementById('lrStepDecaySize').value) || 10,
                     lrExpDecayRate: parseFloat(document.getElementById('lrExpDecayRate').value) || 0.95,
-                    callback:async(ep,trL,tstL)=>{
+                    callback:async(ep,trL,tstL,metricName,metricVal)=>{
                         lossHistory.push({train:trL,test:tstL});
                         drawLossGraph();
                         epochBar.style.width=`${(ep/opts.epochs)*100}%`;
-                        // Display current LR in stats if scheduler is active
-                        const currentLR = nn.getCurrentLearningRate(ep, opts.learningRate, opts); // Need to add getCurrentLearningRate method
+
+                        const currentLR = nn.getCurrentLearningRate(ep -1, opts.learningRate, opts); // ep is 1-based, need 0-based for calc
                         const lrString = opts.lrSchedule !== 'none' ? ` | LR: ${currentLR.toExponential(2)}` : '';
-                        statsEl.innerHTML=`Ep:${ep}/${opts.epochs}|Loss:${trL.toFixed(6)}`+(tstL!==null?`|Val:${tstL.toFixed(6)}`:'') + lrString;
-                        await new Promise(requestAnimationFrame);
+
+                        let statusText = `Ep:${ep}/${opts.epochs} | Loss:${trL.toFixed(6)}`;
+                        if (tstL !== null) {
+                             statusText += ` | Val Loss:${tstL.toFixed(6)}`;
+                        }
+                        // {{ Add: Display metric in status if available }}
+                        if (metricName && metricVal !== null && !isNaN(metricVal)) {
+                             statusText += ` | Val ${metricName}:${metricVal.toFixed(4)}`;
+                        }
+                         statusText += lrString;
+                         statsEl.innerHTML = statusText;
+
+                        await new Promise(requestAnimationFrame); // Yield for UI update
                     }
                 };
                 statsEl.innerHTML=`Training (${opts.optimizer}, ${opts.lossFunction}` + (opts.lrSchedule !== 'none' ? `, ${opts.lrSchedule} LR` : '') + `)...`;


### PR DESCRIPTION
…e UI/training code

- Extend the architecture template dropdown by adding new options:
  - "Transformer Encoder"
  - "Residual Attention"
- Define new templates in architectureTemplates: • transformerEncoder: 8 hidden layers that combine pre-norm LayerNorm, multi-head attention (3 heads then 4 heads), FFN (dense with ReLU), and dropout; final activation hint is set to 'none'. • residual-attention: 5 layers stacking LayerNorm, attention (3 heads), a dense layer (32, ReLU), dropout, and a closing LayerNorm.
- Refactor training and optimizer update sections:
  - Remove duplicate code in activation functions and parameter updates.
  - Improve learning rate calculation and callback logging (including displaying LR, validation loss, and metric updates).
  - Refine final layer activation logic for autoencoder vs. classification/regression setups.
  
These changes enhance model configuration flexibility and overall training UI/flow.