### PR TITLE
Add training pause logic and node-safe export

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,6 +669,8 @@
           <div class="widget-title">Model Management</div>
           <div class="button-group">
             <button id="trainButton">Train Model</button>
+            <button id="pauseButton">Pause</button>
+            <button id="resumeButton">Resume</button>
             <button id="saveButton">Save Model</button>
             <button id="loadButton">Load Model</button>
             <button id="unloadButton">Unload Model</button>


### PR DESCRIPTION
## Summary
- make training pausable with `isPaused` flag and pause/resume methods
- hook pause/resume buttons in UI
- guard DOM initialization to allow requiring in Node
- export `oblix` class when used as a module

## Testing
- `node -e "require('./src/oblix.js')" && echo PASS`
