### PR TITLE
Add training pause/resume controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,6 +669,8 @@
           <div class="widget-title">Model Management</div>
           <div class="button-group">
             <button id="trainButton">Train Model</button>
+            <button id="pauseButton">Pause</button>
+            <button id="resumeButton">Resume</button>
             <button id="saveButton">Save Model</button>
             <button id="loadButton">Load Model</button>
             <button id="unloadButton">Unload Model</button>


### PR DESCRIPTION
## Summary
- make `oblix` class pausable with `isPaused`, `pauseTraining`, `resumeTraining`
- check pause state inside training loops
- expose Pause/Resume buttons in the UI and hook them to the new methods
- show paused status message and update control state while training

## Testing
- `node -e "require('./src/oblix.js')" && echo PASS || echo FAIL` *(fails with SyntaxError)*