### PR TITLE
Add Node-based test harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "oblix",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node tests/run.js"
+  }
+}

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import assert from 'assert';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.js') && f !== 'run.js');
+
+let passed = 0;
+let failed = 0;
+
+for (const file of files) {
+  try {
+    const mod = await import(`./${file}`);
+    if (typeof mod.run === 'function') {
+      await mod.run(assert);
+      console.log(`${file}: OK`);
+      passed++;
+    } else {
+      console.log(`${file}: No run() exported`);
+    }
+  } catch (err) {
+    failed++;
+    console.error(`${file}: FAIL`);
+    console.error(err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} test file(s) failed.`);
+  process.exit(1);
+} else {
+  console.log(`\nAll ${passed} test file(s) passed.`);
+}

--- a/tests/test_calculateAccuracy.js
+++ b/tests/test_calculateAccuracy.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import { oblixUtils } from '../src/utils.js';
+
+export async function run() {
+  const preds = [
+    [0.1, 0.9],
+    [0.8, 0.2]
+  ];
+  const oneHotTargets = [
+    [0, 1],
+    [1, 0]
+  ];
+  const acc = oblixUtils.calculateAccuracy(preds, oneHotTargets);
+  assert.ok(Math.abs(acc - 1) < 1e-6);
+}

--- a/tests/test_generateXORData.js
+++ b/tests/test_generateXORData.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { oblixUtils } from '../src/utils.js';
+
+export async function run() {
+  const data = oblixUtils.generateXORData(5, 0);
+  assert.strictEqual(data.length, 5);
+  for (const item of data) {
+    assert.strictEqual(item.input.length, 2);
+    assert.strictEqual(item.output.length, 1);
+    const a = Math.round(item.input[0]);
+    const b = Math.round(item.input[1]);
+    assert.strictEqual((a + b) % 2, item.output[0]);
+  }
+}

--- a/tests/test_positionalEncoding.js
+++ b/tests/test_positionalEncoding.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import { oblixUtils } from '../src/utils.js';
+
+export async function run() {
+  const input = new Float32Array([0, 0]);
+  const result = oblixUtils.positionalEncoding(input);
+  assert.strictEqual(result.length, 2);
+  assert.ok(Math.abs(result[0] - 0) < 1e-6);
+  assert.ok(Math.abs(result[1] - Math.cos(1)) < 1e-6);
+
+  const arrInput = [1, 2];
+  const out2 = oblixUtils.positionalEncoding(arrInput);
+  assert.strictEqual(out2.length, 2);
+  assert.ok(out2 instanceof Float32Array);
+}


### PR DESCRIPTION
## Summary
- add `package.json` to enable ES modules for Node tests
- create simple `tests/run.js` harness that loads each test file
- test `oblixUtils` helper functions

## Testing
- `node tests/run.js`
