### PR TITLE
Add layer ops tests

### DIFF
--- a/tests/test_attention.js
+++ b/tests/test_attention.js
@@ -1,0 +1,35 @@
+import assert from 'assert';
+import { oblixLayerOps } from '../src/layers.js';
+
+export async function run() {
+  const ctxF = { debug: false, forwardCache: { activations: [0], attentionIntermediates: [] } };
+  const input = new Float32Array([1, 2, 3, 4]);
+  const output = oblixLayerOps.attentionForward(ctxF, input, 2);
+  const expected = [1.6697615, 1.8044296, 3.8929582, 3.9441929];
+  for (let i = 0; i < expected.length; i++) {
+    assert.ok(Math.abs(output[i] - expected[i]) < 1e-4);
+  }
+  const cache = ctxF.forwardCache.attentionIntermediates[0];
+  assert.ok(cache && cache.input instanceof Float32Array);
+  const dOutput = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+  const { dInput } = oblixLayerOps.attentionBackward({ debug: false }, dOutput, cache);
+  assert.strictEqual(dInput.length, input.length);
+  const eps = 1e-3;
+  const numericGrad = new Float32Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const plus = input.slice();
+    plus[i] += eps;
+    const minus = input.slice();
+    minus[i] -= eps;
+    const outPlus = oblixLayerOps.attentionForward({ debug: false, forwardCache: { activations: [0], attentionIntermediates: [] } }, plus, 2);
+    const outMinus = oblixLayerOps.attentionForward({ debug: false, forwardCache: { activations: [0], attentionIntermediates: [] } }, minus, 2);
+    let grad = 0;
+    for (let j = 0; j < dOutput.length; j++) {
+      grad += (outPlus[j] - outMinus[j]) * dOutput[j];
+    }
+    numericGrad[i] = grad / (2 * eps);
+  }
+  for (let i = 0; i < input.length; i++) {
+    assert.ok(Math.abs(dInput[i] - numericGrad[i]) < 1e-3);
+  }
+}

--- a/tests/test_dropout.js
+++ b/tests/test_dropout.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { oblixLayerOps } from '../src/layers.js';
+
+export async function run() {
+  const ctx1 = { isTraining: false, debug: false, masks: [], forwardCache: { activations: [0] } };
+  const input = new Float32Array([1, 2, 3]);
+  const out1 = oblixLayerOps.dropoutForward(ctx1, input, 0.5);
+  assert.deepStrictEqual(Array.from(out1), Array.from(input));
+  assert.strictEqual(ctx1.masks[0], null);
+  const dOut = new Float32Array([0.1, 0.2, 0.3]);
+  const dPass = oblixLayerOps.dropoutBackward(ctx1, dOut, 0);
+  assert.deepStrictEqual(Array.from(dPass), Array.from(dOut));
+
+  const ctx2 = { isTraining: true, debug: false, masks: [], forwardCache: { activations: [0] } };
+  const seq = [0.1, 0.6, 0.7];
+  let idx = 0;
+  const orig = Math.random;
+  Math.random = () => seq[idx++] ?? 0;
+  const out2 = oblixLayerOps.dropoutForward(ctx2, input, 0.5);
+  Math.random = orig;
+  assert.deepStrictEqual(Array.from(out2), [0, 4, 6]);
+  assert.deepStrictEqual(Array.from(ctx2.masks[0]), [0, 2, 2]);
+  const dIn = oblixLayerOps.dropoutBackward(ctx2, new Float32Array([10, 20, 30]), 0);
+  assert.deepStrictEqual(Array.from(dIn), [0, 40, 60]);
+}

--- a/tests/test_layerNorm.js
+++ b/tests/test_layerNorm.js
@@ -1,0 +1,42 @@
+import assert from 'assert';
+import { oblixLayerOps } from '../src/layers.js';
+
+export async function run() {
+  const ctxF = { debug: false, epsilon: 1e-5, forwardCache: { activations: [0], layerNormIntermediates: [] } };
+  const input = new Float32Array([1, 2, 3]);
+  const gamma = new Float32Array([1, 1, 1]);
+  const beta = new Float32Array([0, 0, 0]);
+  const cache = oblixLayerOps.layerNormForward(ctxF, input, gamma, beta);
+  const expectedNorm = [-1.2247357, 0, 1.2247357];
+  for (let i = 0; i < expectedNorm.length; i++) {
+    assert.ok(Math.abs(cache.normalizedInput[i] - expectedNorm[i]) < 1e-4);
+    assert.ok(Math.abs(cache.output[i] - expectedNorm[i]) < 1e-4);
+  }
+  const dOutput = new Float32Array([0.1, 0.2, 0.3]);
+  const back = oblixLayerOps.layerNormBackward({ debug: false, epsilon: 1e-5 }, dOutput, cache);
+  assert.strictEqual(back.dInput.length, input.length);
+  assert.strictEqual(back.dGamma.length, input.length);
+  assert.strictEqual(back.dBeta.length, input.length);
+  for (let i = 0; i < input.length; i++) {
+    assert.ok(Math.abs(back.dGamma[i] - dOutput[i] * cache.normalizedInput[i]) < 1e-6);
+    assert.ok(Math.abs(back.dBeta[i] - dOutput[i]) < 1e-6);
+  }
+  const eps = 1e-3;
+  const numericGrad = new Float32Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const plus = input.slice();
+    plus[i] += eps;
+    const minus = input.slice();
+    minus[i] -= eps;
+    const outPlus = oblixLayerOps.layerNormForward({ debug: false, epsilon: 1e-5, forwardCache: { activations: [0], layerNormIntermediates: [] } }, plus, gamma, beta).output;
+    const outMinus = oblixLayerOps.layerNormForward({ debug: false, epsilon: 1e-5, forwardCache: { activations: [0], layerNormIntermediates: [] } }, minus, gamma, beta).output;
+    let grad = 0;
+    for (let j = 0; j < dOutput.length; j++) {
+      grad += (outPlus[j] - outMinus[j]) * dOutput[j];
+    }
+    numericGrad[i] = grad / (2 * eps);
+  }
+  for (let i = 0; i < input.length; i++) {
+    assert.ok(Math.abs(back.dInput[i] - numericGrad[i]) < 1e-3);
+  }
+}

--- a/tests/test_softmax.js
+++ b/tests/test_softmax.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import { oblixLayerOps } from '../src/layers.js';
+
+export async function run() {
+  const ctxF = { debug: false, forwardCache: { activations: [0], softmaxOutputs: [] } };
+  const input = new Float32Array([1, 2, 3]);
+  const out = oblixLayerOps.softmaxForward(ctxF, input);
+  const expected = [0.09003057, 0.24472848, 0.66524094];
+  for (let i = 0; i < expected.length; i++) {
+    assert.ok(Math.abs(out[i] - expected[i]) < 1e-4);
+  }
+  const cached = ctxF.forwardCache.softmaxOutputs[0];
+  assert.ok(cached && cached.length === input.length);
+  const dOut = new Float32Array([0.1, 0.2, 0.3]);
+  const dIn = oblixLayerOps.softmaxBackward(ctxF, dOut, 0);
+  assert.deepStrictEqual(Array.from(dIn), Array.from(dOut));
+}


### PR DESCRIPTION
## Summary
- add tests for attention forward/backward logic
- add layer norm forward/backward tests
- verify dropout behavior in both training and eval modes
- check softmax forward/backward

## Testing
- `node tests/run.js`