### PR TITLE
Fix accuracy function typed array bug

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,10 +78,13 @@ export const oblixUtils = {
 
       let targetIndex = -1;
 
+      const isTypedArray =
+        ArrayBuffer.isView(targetInfo) && !(targetInfo instanceof DataView);
+
       if (typeof targetInfo === "number" && Number.isInteger(targetInfo)) {
         targetIndex = targetInfo;
       } else if (
-        Array.isArray(targetInfo) &&
+        (Array.isArray(targetInfo) || isTypedArray) &&
         targetInfo.length === predVec.length
       ) {
         for (let j = 0; j < targetInfo.length; j++) {

--- a/tests/test_calculateAccuracy.js
+++ b/tests/test_calculateAccuracy.js
@@ -12,4 +12,15 @@ export async function run() {
   ];
   const acc = oblixUtils.calculateAccuracy(preds, oneHotTargets);
   assert.ok(Math.abs(acc - 1) < 1e-6);
+
+  const predsTyped = [
+    new Float32Array([0.1, 0.9]),
+    new Float32Array([0.8, 0.2])
+  ];
+  const typedTargets = [
+    new Float32Array([0, 1]),
+    new Float32Array([1, 0])
+  ];
+  const accTyped = oblixUtils.calculateAccuracy(predsTyped, typedTargets);
+  assert.ok(Math.abs(accTyped - 1) < 1e-6);
 }


### PR DESCRIPTION
## Summary
- support typed array targets in calculateAccuracy
- test typed array handling

## Testing
- `node tests/run.js`