### PR TITLE
Add basic benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Clone or download this repository (or at least the `index.html` file and accompa
 
 Oblix is implemented in pure JavaScript with no external library dependencies for the core neural network logic. The `index.html` entry point imports modules from the `src` directory where all functionality resides.
 
+## Benchmarks
+
+Run all performance benchmarks with:
+
+```bash
+node benchmark/run.js
+```
+
+
 ## License
 
 Released under the [MIT License](LICENSE).

--- a/benchmark/bench_generateXORData.js
+++ b/benchmark/bench_generateXORData.js
@@ -1,0 +1,16 @@
+import { oblixUtils } from '../src/utils.js';
+import { performance } from 'perf_hooks';
+
+export async function run() {
+  const samples = 10000;
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixUtils.generateXORData(samples, 0.1);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`generateXORData: ${samples} samples -> avg ${avg.toFixed(2)} ms`);
+}

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.js') && f !== 'run.js');
+
+for (const file of files) {
+  try {
+    const mod = await import(`./${file}`);
+    if (typeof mod.run === 'function') {
+      await mod.run();
+    } else {
+      console.log(`${file}: No run() exported`);
+    }
+  } catch (err) {
+    console.error(`${file}: ERROR`);
+    console.error(err);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node tests/run.js"
+    "test": "node tests/run.js",
+    "benchmark": "node benchmark/run.js"
   }
 }


### PR DESCRIPTION
## Summary
- add `benchmark` folder for running performance tests
- measure `generateXORData` in `bench_generateXORData.js`
- add benchmark runner
- document benchmark usage in README
- expose `benchmark` npm script

## Testing
- `node benchmark/run.js`
- `node tests/run.js`
