### PR TITLE
Add missing benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Oblix is implemented in pure JavaScript with no external library dependencies fo
 ## Benchmarks
 
 The `benchmark/` directory contains small scripts that measure the speed of the
-data generation helpers such as `generateXORData`, `generateLinearData`,
-`generateCircularData` and `generateGaussianBlobs`.
+utility helpers. Benchmarks are provided for the data generation routines
+`generateXORData`, `generateLinearData`, `generateCircularData` and
+`generateGaussianBlobs`. Additional scripts cover `gaussianRandom`,
+`positionalEncoding`, `calculateAccuracy` and `calculateRSquared`.
 
 Run all performance benchmarks with:
 

--- a/benchmark/bench_calculateAccuracy.js
+++ b/benchmark/bench_calculateAccuracy.js
@@ -1,0 +1,32 @@
+import { oblixUtils } from '../src/utils.js';
+import { performance } from 'perf_hooks';
+
+function prepData(samples, classes) {
+  const preds = [];
+  const targets = [];
+  for (let i = 0; i < samples; i++) {
+    const pred = [];
+    for (let j = 0; j < classes; j++) pred.push(Math.random());
+    preds.push(pred);
+    const t = new Array(classes).fill(0);
+    t[Math.floor(Math.random() * classes)] = 1;
+    targets.push(t);
+  }
+  return { preds, targets };
+}
+
+export async function run() {
+  const samples = 10000;
+  const classes = 3;
+  const { preds, targets } = prepData(samples, classes);
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixUtils.calculateAccuracy(preds, targets);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`calculateAccuracy: ${samples} samples -> avg ${avg.toFixed(2)} ms`);
+}

--- a/benchmark/bench_calculateRSquared.js
+++ b/benchmark/bench_calculateRSquared.js
@@ -1,0 +1,28 @@
+import { oblixUtils } from '../src/utils.js';
+import { performance } from 'perf_hooks';
+
+function prepData(samples) {
+  const targets = [];
+  const preds = [];
+  for (let i = 0; i < samples; i++) {
+    const t = Math.random();
+    targets.push(t);
+    preds.push(t + (Math.random() - 0.5) * 0.1);
+  }
+  return { preds, targets };
+}
+
+export async function run() {
+  const samples = 10000;
+  const { preds, targets } = prepData(samples);
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixUtils.calculateRSquared(preds, targets);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`calculateRSquared: ${samples} samples -> avg ${avg.toFixed(2)} ms`);
+}

--- a/benchmark/bench_gaussianRandom.js
+++ b/benchmark/bench_gaussianRandom.js
@@ -1,0 +1,18 @@
+import { oblixUtils } from '../src/utils.js';
+import { performance } from 'perf_hooks';
+
+export async function run() {
+  const samples = 1000000;
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    for (let j = 0; j < samples; j++) {
+      oblixUtils.gaussianRandom();
+    }
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`gaussianRandom: ${samples} calls -> avg ${avg.toFixed(2)} ms`);
+}

--- a/benchmark/bench_positionalEncoding.js
+++ b/benchmark/bench_positionalEncoding.js
@@ -1,0 +1,17 @@
+import { oblixUtils } from '../src/utils.js';
+import { performance } from 'perf_hooks';
+
+export async function run() {
+  const dims = 256;
+  const input = new Float32Array(dims).fill(0.5);
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixUtils.positionalEncoding(input);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`positionalEncoding: ${dims} dims -> avg ${avg.toFixed(2)} ms`);
+}


### PR DESCRIPTION
**Context**
Oblix includes basic benchmarks for its data-generation helpers, but other utility functions were not covered. Measuring these functions helps track performance regressions.

**Description**
Added benchmark scripts for `gaussianRandom`, `positionalEncoding`, `calculateAccuracy` and `calculateRSquared`. Updated README to document all available benchmarks. Each script follows the existing style and is executed via `benchmark/run.js`.

**Changes in the codebase**
- Added four new files under `benchmark/` measuring the performance of utility helpers.
- Updated the Benchmarks section in README to mention all benchmark scripts.
