### PR TITLE
Add attentionForward benchmark

### DIFF
--- a/benchmark/bench_attentionForward.js
+++ b/benchmark/bench_attentionForward.js
@@ -1,0 +1,21 @@
+import { oblixLayerOps } from '../src/layers.js';
+import { performance } from 'perf_hooks';
+
+export async function run() {
+  const numHeads = 8;
+  const dims = 128; // divisible by numHeads
+  const input = new Float32Array(dims);
+  for (let i = 0; i < dims; i++) input[i] = Math.random();
+
+  const ctx = { debug: false, forwardCache: { activations: [0], attentionIntermediates: [] } };
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixLayerOps.attentionForward(ctx, input, numHeads);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`attentionForward: ${dims}-dim, ${numHeads} heads -> avg ${avg.toFixed(2)} ms`);
+}

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -2,7 +2,10 @@ import fs from 'fs';
 import path from 'path';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
-const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.js') && f !== 'run.js');
+const files = fs
+  .readdirSync(__dirname)
+  .filter(f => f.endsWith('.js') && f !== 'run.js')
+  .sort();
 
 for (const file of files) {
   try {


### PR DESCRIPTION
## Context
Add missing benchmark for multi-head attention to evaluate performance of attention layer operations.

## Description
Implemented `bench_attentionForward.js` that benchmarks `oblixLayerOps.attentionForward` using an example with 8 attention heads. The benchmark follows existing patterns to measure execution time over several runs. Updated `benchmark/run.js` to sort benchmark files ensuring consistent execution order and automatic inclusion of the new benchmark.

## Changes in the codebase
- **benchmark/bench_attentionForward.js** – new benchmark measuring attention forward pass performance
- **benchmark/run.js** – reads benchmark files in sorted order to include new benchmark