### PR TITLE
Add dropout forward benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `benchmark/` directory contains small scripts that measure the speed of the
 utility helpers. Benchmarks are provided for the data generation routines
 `generateXORData`, `generateLinearData`, `generateCircularData` and
 `generateGaussianBlobs`. Additional scripts cover `gaussianRandom`,
-`positionalEncoding`, `calculateAccuracy` and `calculateRSquared`.
+`positionalEncoding`, `calculateAccuracy`, `calculateRSquared` and `dropoutForward`.
 
 Run all performance benchmarks with:
 

--- a/benchmark/bench_dropoutForward.js
+++ b/benchmark/bench_dropoutForward.js
@@ -1,0 +1,19 @@
+import { oblixLayerOps } from '../src/layers.js';
+import { performance } from 'perf_hooks';
+
+export async function run() {
+  const size = 1000000;
+  const input = new Float32Array(size).fill(1);
+  const ctx = { isTraining: true, debug: false, masks: [], forwardCache: { activations: [0] } };
+  const rate = 0.5;
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixLayerOps.dropoutForward(ctx, input, rate);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`dropoutForward: ${size} elems -> avg ${avg.toFixed(2)} ms`);
+}


### PR DESCRIPTION
**Context**
Expands the set of performance benchmarks to cover dropout layer operations.

**Description**
A new benchmark script measures the execution time of `oblixLayerOps.dropoutForward` when run in training mode with a standard dropout rate. The script creates a large input tensor, runs the function multiple times and reports the average runtime. The benchmark runner automatically executes this new file.

**Changes in the codebase**
- Added `benchmark/bench_dropoutForward.js` implementing the timing loop for `dropoutForward`.
- Documented the new benchmark in the README.
