### PR TITLE
Add softmaxForward benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The `benchmark/` directory contains small scripts that measure the speed of the
 utility helpers. Benchmarks are provided for the data generation routines
 `generateXORData`, `generateLinearData`, `generateCircularData` and
 `generateGaussianBlobs`. Additional scripts cover `gaussianRandom`,
-`positionalEncoding`, `calculateAccuracy` and `calculateRSquared`.
+`positionalEncoding`, `calculateAccuracy`, `calculateRSquared` and
+`softmaxForward`.
 
 Run all performance benchmarks with:
 

--- a/benchmark/bench_softmaxForward.js
+++ b/benchmark/bench_softmaxForward.js
@@ -1,0 +1,18 @@
+import { oblixLayerOps } from '../src/layers.js';
+import { performance } from 'perf_hooks';
+
+export async function run() {
+  const dims = 512;
+  const input = new Float32Array(dims);
+  for (let i = 0; i < dims; i++) input[i] = Math.random();
+  const runs = 5;
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    oblixLayerOps.softmaxForward({}, input);
+    const end = performance.now();
+    times.push(end - start);
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+  console.log(`softmaxForward: ${dims} dims -> avg ${avg.toFixed(2)} ms`);
+}

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -2,7 +2,10 @@ import fs from 'fs';
 import path from 'path';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
-const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.js') && f !== 'run.js');
+const files = fs
+  .readdirSync(__dirname)
+  .filter(f => f.endsWith('.js') && f !== 'run.js')
+  .sort();
 
 for (const file of files) {
   try {


### PR DESCRIPTION
**Context**
The benchmark suite measures various utility functions. `oblixLayerOps.softmaxForward` lacked timing metrics.

**Description**
Implemented a new benchmark script `bench_softmaxForward.js` to evaluate the speed of the softmax forward pass on a 512‑dimensional vector. The benchmark runs multiple iterations, averages the durations and reports the result. `benchmark/run.js` now sorts benchmark filenames to ensure new benchmarks like this one are executed consistently. Documentation lists the new script.

**Changes in the codebase**
- Added `benchmark/bench_softmaxForward.js` which times `oblixLayerOps.softmaxForward`.
- Updated `benchmark/run.js` to sort benchmark files before execution.
- Mentioned `softmaxForward` benchmark in README.