### PR TITLE
Improve GELU and gaussianRandom performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ utility helpers. Benchmarks are provided for the data generation routines
 `generateXORData`, `generateLinearData`, `generateCircularData` and
 `generateGaussianBlobs`. Additional scripts cover `gaussianRandom`,
 `positionalEncoding`, `calculateAccuracy`, `calculateRSquared` and
-`softmaxForward`, and `dropoutForward`.
+`softmaxForward`, and `dropoutForward`. Several functions, including the GELU
+activation and `gaussianRandom` helper, use optimized approximations for
+better performance.
 
 Run all performance benchmarks with:
 

--- a/src/activations.js
+++ b/src/activations.js
@@ -11,12 +11,11 @@ export const oblixActivations = {
         return Math.max(0, x);
       case "leakyrelu":
         return x > 0 ? x : alpha * x;
-      case "gelu":
-        return (
-          0.5 *
-          x *
-          (1 + Math.tanh(Math.sqrt(2 / Math.PI) * (x + 0.044715 * x ** 3)))
-        );
+      case "gelu": {
+        const k = 0.7978845608; // sqrt(2/pi)
+        const x3 = x * x * x;
+        return 0.5 * x * (1 + Math.tanh(k * (x + 0.044715 * x3)));
+      }
       case "selu":
         const sa = 1.67326,
           ss = 1.0507;
@@ -48,13 +47,15 @@ export const oblixActivations = {
         return x > 0 ? 1 : 0;
       case "leakyrelu":
         return x > 0 ? 1 : alpha;
-      case "gelu":
-        const k = Math.sqrt(2 / Math.PI),
-          inner = k * (x + 0.044715 * x ** 3),
-          tanh_inner = Math.tanh(inner),
-          d_inner_dx = k * (1 + 0.134145 * x ** 2),
-          sech_sq_inner = 1 - tanh_inner ** 2;
-        return 0.5 * (1 + tanh_inner) + 0.5 * x * sech_sq_inner * d_inner_dx;
+      case "gelu": {
+        const k = 0.7978845608; // sqrt(2/pi)
+        const x2 = x * x;
+        const inner = k * (x + 0.044715 * x * x2);
+        const tanh_inner = Math.tanh(inner);
+        const sech_sq = 1 - tanh_inner * tanh_inner;
+        const d_inner_dx = k * (1 + 0.134145 * x2);
+        return 0.5 * (1 + tanh_inner) + 0.5 * x * sech_sq * d_inner_dx;
+      }
       case "selu":
         const sa = 1.67326,
           ss = 1.0507;

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,15 +181,12 @@ export const oblixUtils = {
       this._gaussian_spare = null;
       return spare;
     }
-    let u, v, s;
-    do {
-      u = Math.random() * 2 - 1;
-      v = Math.random() * 2 - 1;
-      s = u * u + v * v;
-    } while (s >= 1 || s === 0);
-    const mul = Math.sqrt((-2.0 * Math.log(s)) / s);
-    this._gaussian_spare = v * mul;
-    return u * mul;
+    const u1 = 1 - Math.random();
+    const u2 = Math.random();
+    const r = Math.sqrt(-2 * Math.log(u1));
+    const theta = 2 * Math.PI * u2;
+    this._gaussian_spare = r * Math.sin(theta);
+    return r * Math.cos(theta);
   },
 
   generateXORData: function (numSamples, noise) {


### PR DESCRIPTION
**Context**
The slowest benchmarks were the GELU activation and gaussianRandom helper. Optimising them helps speed up neural network experiments.

**Description**
The GELU implementation now precomputes constants and avoids expensive calls, while gaussianRandom uses the Box–Muller transform without a rejection loop. README notes these optimisations.

**Changes in the codebase**
- rewrote GELU forward and derivative calculations to use precomputed constant and simple multiplications
- replaced polar Box–Muller method with direct transform in gaussianRandom
- documented optimisations in README