### PR TITLE
Optimize dropoutForward randomness

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Clone or download this repository (or at least the `index.html` file and accompa
 
 Oblix is implemented in pure JavaScript with no external library dependencies for the core neural network logic. The `index.html` entry point imports modules from the `src` directory where all functionality resides.
 
+Dropout layers generate masks using `crypto.getRandomValues` for performance. A
+custom `randomFillFn` can be attached to the network context to supply
+deterministic values during testing.
+
 ## Benchmarks
 
 The `benchmark/` directory contains small scripts that measure the speed of the

--- a/src/layers.js
+++ b/src/layers.js
@@ -432,8 +432,22 @@ export const oblixLayerOps = {
         ` Input type=${input.constructor.name}, len=${N}, Rate=${rate}, Scale=${scale.toFixed(4)}`,
       );
 
+    const randInts = new Uint32Array(N);
+    const fill = context.randomFillFn;
+    if (typeof fill === 'function') {
+      fill(randInts);
+    } else if (typeof globalThis.crypto !== 'undefined' &&
+               typeof globalThis.crypto.getRandomValues === 'function') {
+      globalThis.crypto.getRandomValues(randInts);
+    } else {
+      for (let i = 0; i < N; i++) {
+        randInts[i] = (Math.random() * 0xffffffff) >>> 0;
+      }
+    }
+
+    const threshold = rate * 4294967296;
     for (let i = 0; i < N; i++) {
-      if (Math.random() > rate) {
+      if (randInts[i] >= threshold) {
         mask[i] = scale;
         output[i] = input[i] * scale;
       } else {

--- a/tests/test_dropout.js
+++ b/tests/test_dropout.js
@@ -14,10 +14,14 @@ export async function run() {
   const ctx2 = { isTraining: true, debug: false, masks: [], forwardCache: { activations: [0] } };
   const seq = [0.1, 0.6, 0.7];
   let idx = 0;
-  const orig = Math.random;
-  Math.random = () => seq[idx++] ?? 0;
+  const orig = crypto.getRandomValues;
+  crypto.getRandomValues = arr => {
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = Math.floor((seq[idx++] ?? 0) * 4294967296);
+    }
+  };
   const out2 = oblixLayerOps.dropoutForward(ctx2, input, 0.5);
-  Math.random = orig;
+  crypto.getRandomValues = orig;
   assert.deepStrictEqual(Array.from(out2), [0, 4, 6]);
   assert.deepStrictEqual(Array.from(ctx2.masks[0]), [0, 2, 2]);
   const dIn = oblixLayerOps.dropoutBackward(ctx2, new Float32Array([10, 20, 30]), 0);


### PR DESCRIPTION
**Context**
`dropoutForward` previously relied on a `Math.random()` call per array entry which slowed down large tensors.

**Description**
The function now generates all random bits at once via `crypto.getRandomValues` (or a provided `randomFillFn` callback). The mask is then derived from these pre-filled integers, reducing calls to `Math.random` and improving performance. Tests provide deterministic values by overriding `crypto.getRandomValues`.

**Changes in the codebase**
- Reworked `dropoutForward` in `layers.js` to bulk-generate randomness and added optional `context.randomFillFn` hook.
- Updated dropout unit test to patch `crypto.getRandomValues`.
- Documented the new mechanism in the README.
