### PR TITLE
Fix theme toggle init

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import { Oblix } from "./network.js";
 import { oblixUtils } from "./utils.js";
 
 if (typeof document !== "undefined") {
-  document.addEventListener("DOMContentLoaded", () => {
+  const init = () => {
   const nn = new Oblix(true);
   let lossHistory = [];
   let playbackHistory = [];
@@ -1596,6 +1596,11 @@ if (typeof document !== "undefined") {
       statsEl.innerHTML = `<span class="error">Unload error: ${error.message}</span>`;
     }
   });
-});
+  };
+  if (document.readyState !== "loading") {
+    init();
+  } else {
+    document.addEventListener("DOMContentLoaded", init);
+  }
 }
 


### PR DESCRIPTION
**Context**
The light mode checkbox was not applying the light theme because the UI initialization code never ran when the page finished loading. The script is loaded at the bottom of `index.html`, so the `DOMContentLoaded` listener was registered after the event already fired.

**Description**
Wrapped the UI setup in an `init` function and call it immediately if the DOM has already loaded, otherwise attach a `DOMContentLoaded` listener. This ensures theme toggling and other UI features initialize correctly no matter when the script runs.

**Changes in the codebase**
- Replaced the old `DOMContentLoaded` wrapper in `src/main.js` with an `init` function.
- Added logic to call `init` based on `document.readyState`.
