### PR TITLE
Refactor dropout randomness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Oblix is implemented in pure JavaScript with no external library dependencies fo
 
 Dropout layers generate masks using `crypto.getRandomValues` for performance. A
 custom `randomFillFn` can be attached to the network context to supply
-deterministic values during testing.
+deterministic values during testing. The helper `oblixUtils.fillRandomInts`
+implements this fallback logic.
 
 ## Benchmarks
 

--- a/src/layers.js
+++ b/src/layers.js
@@ -1,3 +1,5 @@
+import { oblixUtils } from './utils.js';
+
 export const oblixLayerOps = {
   attentionForward: function (context, input, numHeads = 2) {
     if (!(input instanceof Float32Array)) {
@@ -433,17 +435,7 @@ export const oblixLayerOps = {
       );
 
     const randInts = new Uint32Array(N);
-    const fill = context.randomFillFn;
-    if (typeof fill === 'function') {
-      fill(randInts);
-    } else if (typeof globalThis.crypto !== 'undefined' &&
-               typeof globalThis.crypto.getRandomValues === 'function') {
-      globalThis.crypto.getRandomValues(randInts);
-    } else {
-      for (let i = 0; i < N; i++) {
-        randInts[i] = (Math.random() * 0xffffffff) >>> 0;
-      }
-    }
+    oblixUtils.fillRandomInts(randInts, context.randomFillFn);
 
     const threshold = rate * 4294967296;
     for (let i = 0; i < N; i++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -174,6 +174,21 @@ export const oblixUtils = {
     return 1 - ssRes / ssTot;
   },
 
+  fillRandomInts: function (arr, randomFillFn) {
+    if (typeof randomFillFn === 'function') {
+      randomFillFn(arr);
+    } else if (
+      typeof globalThis.crypto !== 'undefined' &&
+      typeof globalThis.crypto.getRandomValues === 'function'
+    ) {
+      globalThis.crypto.getRandomValues(arr);
+    } else {
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = (Math.random() * 0xffffffff) >>> 0;
+      }
+    }
+  },
+
   _TWO_PI: 2 * Math.PI,
   _gaussian_spare: null,
   gaussianRandom: function () {


### PR DESCRIPTION
**Context**
The project uses dropout layers that generate masks via repeated random integer generation logic. This code was duplicated and hard to mock for tests.

**Description**
A new helper `fillRandomInts` centralizes the logic of filling `Uint32Array` with random values. It supports providing a custom `randomFillFn` or falling back to `crypto.getRandomValues` and `Math.random`. Dropout now relies on this helper, reducing complexity. Documentation mentions the helper.

**Changes in the codebase**
- Added `fillRandomInts` to `src/utils.js`.
- Updated `src/layers.js` to import `oblixUtils` and use the helper during dropout forward pass.
- Documented the helper usage in `README.md`.
