### PR TITLE
Fix critical oblix bugs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -266,7 +266,10 @@ if (typeof document !== "undefined") {
     const data = [];
     for (let i = 0; i < numSamples; i++) {
       const input = [];
-      for (let j = 0; j < numInputs; j++) input.push(Math.random());
+      for (let j = 0; j < numInputs; j++) {
+        // Ensure input values are between 0.01 and 0.99
+        input.push(0.01 + Math.random() * 0.98);
+      }
       const output = [];
       for (let j = 0; j < numOutputs; j++) {
         const base = Math.sin(input[0] * Math.PI * 2) * 0.4 + 0.5;

--- a/src/network.js
+++ b/src/network.js
@@ -39,6 +39,7 @@ class Oblix {
     this.decayRate = 0.9;
     this.lastActivations = null;
     this.forwardCache = null;
+    this.lastTrainLoss = null;
 
     if (this.debug)
       console.log(
@@ -74,6 +75,7 @@ class Oblix {
 
     this.lastActivations = null;
     this.forwardCache = null;
+    this.lastTrainLoss = null;
     if (this.debug) console.log("Oblix reset complete.");
   }
 
@@ -954,11 +956,14 @@ class Oblix {
       }
 
       await new Promise((resolve) => setTimeout(resolve, 0));
-      if (lastTrainLoss < earlyStopThreshold) {
+      
+      // Early stopping: check if loss improvement is below threshold
+      if (epoch > 0 && Math.abs(lastTrainLoss - this.lastTrainLoss) < earlyStopThreshold) {
         if (this.debug) console.log(`Early stopping @ Epoch ${epoch + 1}.`);
         epochs = epoch + 1;
         break;
       }
+      this.lastTrainLoss = lastTrainLoss;
     }
 
     const end = Date.now();

--- a/src/optimizers.js
+++ b/src/optimizers.js
@@ -23,18 +23,17 @@ export const oblixOptimizers = {
       const w = context.weights[i];
       const reqW =
         cfg.type === "dense" &&
-        Array.isArray(w) &&
-        w.length > 0 &&
-        Array.isArray(w[0]);
+        w instanceof Float32Array &&
+        w.length > 0;
       const b = context.biases[i];
       const reqB =
-        cfg.type === "dense" && cfg.useBias && Array.isArray(b) && b.length > 0;
+        cfg.type === "dense" && cfg.useBias && b instanceof Float32Array && b.length > 0;
       const g = context.gammas[i];
       const beta = context.betas[i];
       const reqLN =
         cfg.type === "layernorm" &&
-        Array.isArray(g) &&
-        Array.isArray(beta) &&
+        g instanceof Float32Array &&
+        beta instanceof Float32Array &&
         g.length === beta.length &&
         g.length > 0;
 
@@ -45,13 +44,13 @@ export const oblixOptimizers = {
       ) {
         if (reqW) {
           try {
-            const z = () => w.map((r) => r.map(() => 0));
+            const size = w.length;
             if (optimizer === "adam" || optimizer === "adamw") {
-              context.m_dw[i] = z();
-              context.v_dw[i] = z();
+              context.m_dw[i] = new Float32Array(size).fill(0);
+              context.v_dw[i] = new Float32Array(size).fill(0);
             }
             if (optimizer === "rmsprop") {
-              context.s_dw[i] = z();
+              context.s_dw[i] = new Float32Array(size).fill(0);
             }
           } catch (e) {
             console.error(`InitOpt L${i} W err: ${e.message}`);
@@ -62,13 +61,13 @@ export const oblixOptimizers = {
         }
         if (reqB) {
           try {
-            const z = () => b.map(() => 0);
+            const size = b.length;
             if (optimizer === "adam" || optimizer === "adamw") {
-              context.m_db[i] = z();
-              context.v_db[i] = z();
+              context.m_db[i] = new Float32Array(size).fill(0);
+              context.v_db[i] = new Float32Array(size).fill(0);
             }
             if (optimizer === "rmsprop") {
-              context.s_db[i] = z();
+              context.s_db[i] = new Float32Array(size).fill(0);
             }
           } catch (e) {
             console.error(`InitOpt L${i} B err: ${e.message}`);
@@ -79,16 +78,16 @@ export const oblixOptimizers = {
         }
         if (reqLN) {
           try {
-            const z = () => g.map(() => 0);
+            const size = g.length;
             if (optimizer === "adam" || optimizer === "adamw") {
-              context.m_dgamma[i] = z();
-              context.v_dgamma[i] = z();
-              context.m_dbeta[i] = z();
-              context.v_dbeta[i] = z();
+              context.m_dgamma[i] = new Float32Array(size).fill(0);
+              context.v_dgamma[i] = new Float32Array(size).fill(0);
+              context.m_dbeta[i] = new Float32Array(size).fill(0);
+              context.v_dbeta[i] = new Float32Array(size).fill(0);
             }
             if (optimizer === "rmsprop") {
-              context.s_dgamma[i] = z();
-              context.s_dbeta[i] = z();
+              context.s_dgamma[i] = new Float32Array(size).fill(0);
+              context.s_dbeta[i] = new Float32Array(size).fill(0);
             }
           } catch (e) {
             console.error(`InitOpt L${i} LN err: ${e.message}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,12 +131,6 @@ export const oblixUtils = {
 
     const targetMean =
       targets.reduce((sum, val) => sum + val, 0) / targets.length;
-    if (typeof console !== "undefined" && console.log) {
-      console.log(
-        `R² Func Check: Received preds[0]=${predictions[0]} (typeof: ${typeof predictions[0]}), targets[0]=${targets[0]} (typeof: ${typeof targets[0]})`,
-      );
-      console.log(`R² Func Check: Calculated targetMean = ${targetMean}`);
-    }
 
     let ssTot = 0;
     let ssRes = 0;
@@ -144,18 +138,6 @@ export const oblixUtils = {
     for (let i = 0; i < targets.length; i++) {
       const targetVal = targets[i];
       const predVal = predictions[i];
-
-      if (typeof console !== "undefined" && console.log) {
-        const isTargetNum = typeof targetVal === "number";
-        const isPredNum = typeof predVal === "number";
-        const isTargetFinite = isFinite(targetVal);
-        const isPredFinite = isFinite(predVal);
-        if (i === 0) {
-          console.log(
-            `R² Func Loop i=${i}: Checks -> targetNum=${isTargetNum}, predNum=${isPredNum}, targetFinite=${isTargetFinite}, predFinite=${isPredFinite}`,
-          );
-        }
-      }
 
       if (!isFinite(targetVal) || !isFinite(predVal)) {
         console.warn(

--- a/tests/test_optimizers.js
+++ b/tests/test_optimizers.js
@@ -9,16 +9,26 @@ export async function run() {
       { type: 'dense', inputSize: 1, outputSize: 1, useBias: true },
       { type: 'layernorm', inputSize: 1 },
     ],
-    weights: [[ [0.2] ] , null],
-    biases: [[0.1], null],
-    gammas: [null, [1, 1]],
-    betas: [null, [0, 0]],
+    weights: [new Float32Array([0.2]), null],
+    biases: [new Float32Array([0.1]), null],
+    gammas: [null, new Float32Array([1, 1])],
+    betas: [null, new Float32Array([0, 0])],
   };
   oblixOptimizers.initializeState(ctxInit, 'adam');
-  assert.deepStrictEqual(ctxInit.m_dw[0], [[0]]);
-  assert.deepStrictEqual(ctxInit.m_db[0], [0]);
-  assert.deepStrictEqual(ctxInit.m_dgamma[1], [0, 0]);
-  assert.deepStrictEqual(ctxInit.m_dbeta[1], [0, 0]);
+  assert.ok(ctxInit.m_dw[0] instanceof Float32Array);
+  assert.strictEqual(ctxInit.m_dw[0].length, 1);
+  assert.strictEqual(ctxInit.m_dw[0][0], 0);
+  assert.ok(ctxInit.m_db[0] instanceof Float32Array);
+  assert.strictEqual(ctxInit.m_db[0].length, 1);
+  assert.strictEqual(ctxInit.m_db[0][0], 0);
+  assert.ok(ctxInit.m_dgamma[1] instanceof Float32Array);
+  assert.strictEqual(ctxInit.m_dgamma[1].length, 2);
+  assert.strictEqual(ctxInit.m_dgamma[1][0], 0);
+  assert.strictEqual(ctxInit.m_dgamma[1][1], 0);
+  assert.ok(ctxInit.m_dbeta[1] instanceof Float32Array);
+  assert.strictEqual(ctxInit.m_dbeta[1].length, 2);
+  assert.strictEqual(ctxInit.m_dbeta[1][0], 0);
+  assert.strictEqual(ctxInit.m_dbeta[1][1], 0);
 
   function createCtx() {
     return {


### PR DESCRIPTION
Fix critical bugs in optimizer state initialization and early stopping, along with data generation and debug log issues.

The optimizer state initialization incorrectly assumed weights were 2D arrays, while they are 1D Float32Arrays, which would prevent training. The early stopping logic was also flawed, causing premature training termination by checking loss value instead of loss improvement.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-efeaec8e-1b0a-4a52-838b-7ebfef41ae77) · [Cursor](https://cursor.com/background-agent?bcId=bc-efeaec8e-1b0a-4a52-838b-7ebfef41ae77)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)