### PR TITLE
Investigate and fix oblix error

### DIFF
--- a/src/optimized/network.js
+++ b/src/optimized/network.js
@@ -41,6 +41,7 @@ class OptimizedOblix {
     this.lastActivations = null;
     this.forwardCache = null;
     this.lastTrainLoss = null;
+    this.lastOptimizer = 'adam'; // Track last used optimizer
     
     if (this.debug) {
       console.log('Optimized Oblix instance created with performance optimizations');
@@ -139,6 +140,9 @@ class OptimizedOblix {
     this.gammas.push(null);
     this.betas.push(null);
     this.masks.push(null);
+    
+    // After adding a layer, re-initialize optimizer state arrays
+    this.initializeOptimizerState(this.lastOptimizer);
     
     return this;
   }
@@ -270,6 +274,8 @@ class OptimizedOblix {
       callback = null,
     } = options;
     
+    // Track the optimizer type for future state inits
+    this.lastOptimizer = optimizer;
     // Initialize optimizer state
     this.initializeOptimizerState(optimizer);
     

--- a/tests/test_optimizers.js
+++ b/tests/test_optimizers.js
@@ -59,6 +59,7 @@ export async function run() {
 
   // SGD update
   const ctxSgd = createCtx();
+  oblixOptimizers.initializeState(ctxSgd, 'sgd');
   oblixOptimizers.updateParameters(
     ctxSgd,
     [new Float32Array([0.1])],
@@ -81,8 +82,7 @@ export async function run() {
 
   // RMSprop update
   const ctxRms = createCtx();
-  ctxRms.s_dw[0] = new Float32Array([0]);
-  ctxRms.s_db[0] = new Float32Array([0]);
+  oblixOptimizers.initializeState(ctxRms, 'rmsprop');
   oblixOptimizers.updateParameters(
     ctxRms,
     [new Float32Array([0.1])],
@@ -109,10 +109,7 @@ export async function run() {
 
   // Adam update
   const ctxAdam = createCtx();
-  ctxAdam.m_dw[0] = new Float32Array([0]);
-  ctxAdam.v_dw[0] = new Float32Array([0]);
-  ctxAdam.m_db[0] = new Float32Array([0]);
-  ctxAdam.v_db[0] = new Float32Array([0]);
+  oblixOptimizers.initializeState(ctxAdam, 'adam');
   oblixOptimizers.updateParameters(
     ctxAdam,
     [new Float32Array([0.1])],


### PR DESCRIPTION
Initialize optimizer state arrays automatically to fix "Cannot set properties of undefined" error.

This ensures optimizer state arrays are always in sync with the network structure, preventing errors when adding layers or before training.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e3f1fc5a-3af6-4236-ab3b-978068782525) · [Cursor](https://cursor.com/background-agent?bcId=bc-e3f1fc5a-3af6-4236-ab3b-978068782525)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)