### PR TITLE
Fix optimizedoblix layer switch error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -877,7 +877,7 @@ if (typeof document !== "undefined") {
         statsEl.innerHTML = `<span class="error">Error applying template: ${error.message}</span>`;
         architectureTemplateSelect.value = "custom";
       }
-    }, 0);
+    }, 20);
   });
 
   trainButton.addEventListener("click", async () => {

--- a/tests/test_uiElements.js
+++ b/tests/test_uiElements.js
@@ -10,3 +10,39 @@ export async function run() {
 
   assert.ok(html.includes('src="src/main.js"'), 'Main script tag missing');
 }
+
+// Test: Switching architecture templates should not throw errors and should update the UI correctly
+export async function testArchitectureSwitch() {
+  // Simulate a DOM environment
+  const { JSDOM } = await import('jsdom');
+  const html = fs.readFileSync('index.html', 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  
+  // Wait for DOMContentLoaded and scripts to run
+  await new Promise((resolve) => {
+    window.addEventListener('DOMContentLoaded', resolve);
+    if (window.document.readyState === 'complete' || window.document.readyState === 'interactive') {
+      resolve();
+    }
+  });
+  
+  // Simulate switching architectures
+  const select = window.document.getElementById('architectureTemplateSelect');
+  const templates = Array.from(select.options).map(o => o.value).filter(v => v !== 'custom');
+  let errorCaught = false;
+  for (const template of templates) {
+    try {
+      select.value = template;
+      select.dispatchEvent(new window.Event('change', { bubbles: true }));
+      // Wait a bit for async UI update
+      await new Promise(r => setTimeout(r, 30));
+    } catch (e) {
+      errorCaught = true;
+      break;
+    }
+  }
+  assert.ok(!errorCaught, 'Switching architectures should not throw errors');
+}


### PR DESCRIPTION
Fix 'Cannot set properties of undefined' error when switching layer architectures and add a test.

The error "Cannot set properties of undefined (setting '0')" occurred because the code attempted to set values on UI elements for hidden layers before they were fully rendered in the DOM after an architecture switch. This was due to a `setTimeout(0)` being too short. The fix increases this timeout to 20ms to ensure the DOM is ready before accessing the elements. A new test in `test_uiElements.js` simulates architecture switching to prevent regressions.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-20a22fa0-3624-44c3-8e31-1e0647b4180a) · [Cursor](https://cursor.com/background-agent?bcId=bc-20a22fa0-3624-44c3-8e31-1e0647b4180a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)