### PR TITLE
Fix undefined property error

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -496,9 +496,10 @@ class Oblix {
             let out;
 
             this.forwardCache.rawValues[i] = null;
-            this.forwardCache.layerNormIntermediates[i] = null;
-            this.forwardCache.attentionIntermediates[i] = null;
-            this.forwardCache.softmaxOutputs[i] = null;
+            // Initialize cache arrays - don't set to null as layer operations will assign objects
+            // this.forwardCache.layerNormIntermediates[i] = null;
+            // this.forwardCache.attentionIntermediates[i] = null;
+            // this.forwardCache.softmaxOutputs[i] = null;
 
             try {
               if (!(layerInput instanceof Float32Array))


### PR DESCRIPTION
Fix 'Cannot set properties of undefined' error by preventing `null` assignment to forward cache arrays.

The error occurred because the training loop in `src/network.js` was initializing elements of `forwardCache` arrays (e.g., `attentionIntermediates`, `layerNormIntermediates`) to `null`. Subsequently, layer operations in `src/layers.js` attempted to assign objects to these same array indices. When an index pointed to a `null` value, JavaScript tried to set properties on `null`, resulting in the "Cannot set properties of undefined (setting '0')" error. Removing the `null` initialization allows the layer operations to correctly assign objects.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-3c880efe-3720-4a5b-92b5-c76037fe1fe0) · [Cursor](https://cursor.com/background-agent?bcId=bc-3c880efe-3720-4a5b-92b5-c76037fe1fe0)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)