### PR TITLE
Add live chart for running rewards and epsilon

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div>Cumulative Reward: <span id="reward">0</span></div>
     <div>Epsilon: <span id="epsilon">1</span></div>
   </div>
-  <canvas id="rewardChart" width="400" height="200"></canvas>
+  <canvas id="liveChart" width="400" height="200"></canvas>
   <div>
     <label>Epsilon: <input type="range" id="epsilon-slider" min="0" max="1" step="0.01" value="1"><span id="epsilon-value">1</span></label>
   </div>
@@ -43,6 +43,7 @@
     import { RLAgent } from './src/rl/agent.js';
     import { RLTrainer } from './src/rl/training.js';
     import { saveAgent, loadAgent } from './src/rl/storage.js';
+    import { LiveChart } from './src/ui/liveChart.js';
 
     const size = 5;
     const env = new GridWorldEnvironment(size);
@@ -50,8 +51,7 @@
     const gridEl = document.getElementById('grid');
     gridEl.style.setProperty('--size', size);
     
-    const canvas = document.getElementById('rewardChart');
-    const ctx = canvas.getContext('2d');
+    const liveChart = new LiveChart(document.getElementById('liveChart'));
     const epsilonSlider = document.getElementById('epsilon-slider');
     const epsilonValue = document.getElementById('epsilon-value');
     const intervalSlider = document.getElementById('interval-slider');
@@ -80,14 +80,13 @@
 
     const trainer = new RLTrainer(agent, env, {
       intervalMs: 100,
+      liveChart,
       onStep: (state, reward, done, metrics) => {
         render(state);
         document.getElementById('episode').textContent = metrics.episode;
         document.getElementById('steps').textContent = metrics.steps;
         document.getElementById('reward').textContent = metrics.cumulativeReward.toFixed(2);
         document.getElementById('epsilon').textContent = metrics.epsilon.toFixed(2);
-
-        if (done) drawChart();
 
         epsilonSlider.value = metrics.epsilon;
         epsilonValue.textContent = metrics.epsilon.toFixed(2);
@@ -123,34 +122,6 @@
     };
 
     render(env.reset());
-
-    function drawChart() {
-      const rewards = trainer.episodeRewards;
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      if (rewards.length === 0) return;
-      const max = Math.max(...rewards);
-      const min = Math.min(...rewards);
-      const range = max - min || 1;
-      const stepX = canvas.width / Math.max(rewards.length - 1, 1);
-      const points = rewards.map((r, i) => {
-        const x = i * stepX;
-        const y = canvas.height - ((r - min) / range) * canvas.height;
-        return { x, y };
-      });
-      ctx.beginPath();
-      points.forEach(({ x, y }, i) => {
-        if (i === 0) ctx.moveTo(x, y);
-        else ctx.lineTo(x, y);
-      });
-      ctx.strokeStyle = '#4caf50';
-      ctx.stroke();
-      points.forEach(({ x, y }) => {
-        ctx.beginPath();
-        ctx.arc(x, y, 3, 0, Math.PI * 2);
-        ctx.fillStyle = '#4caf50';
-        ctx.fill();
-      });
-    }
   </script>
 </body>
 </html>

--- a/src/rl/training.js
+++ b/src/rl/training.js
@@ -3,8 +3,15 @@ export class RLTrainer {
     this.agent = agent;
     this.env = env;
     this.maxSteps = options.maxSteps ?? 50;
-    this.onStep = options.onStep || null;
     this.intervalMs = options.intervalMs ?? 100;
+    this.liveChart = options.liveChart || null;
+    const userOnStep = options.onStep || null;
+    this.onStep = (state, reward, done, metrics) => {
+      if (userOnStep) userOnStep(state, reward, done, metrics);
+      if (this.liveChart) {
+        this.liveChart.push(metrics.cumulativeReward, metrics.epsilon);
+      }
+    };
     this.isRunning = false;
     this.interval = null;
     this.state = null;

--- a/src/ui/liveChart.js
+++ b/src/ui/liveChart.js
@@ -1,0 +1,44 @@
+export class LiveChart {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.rewards = [];
+    this.epsilons = [];
+  }
+
+  push(reward, epsilon) {
+    this.rewards.push(reward);
+    this.epsilons.push(epsilon);
+    this.draw();
+  }
+
+  draw() {
+    const { ctx, canvas, rewards, epsilons } = this;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (rewards.length === 0) return;
+    const maxReward = Math.max(...rewards);
+    const minReward = Math.min(...rewards);
+    const rewardRange = maxReward - minReward || 1;
+    const stepX = canvas.width / Math.max(rewards.length - 1, 1);
+    ctx.beginPath();
+    rewards.forEach((r, i) => {
+      const x = i * stepX;
+      const y = canvas.height - ((r - minReward) / rewardRange) * canvas.height;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = '#4caf50';
+    ctx.stroke();
+
+    const epsRange = 1;
+    ctx.beginPath();
+    epsilons.forEach((e, i) => {
+      const x = i * stepX;
+      const y = canvas.height - (e / epsRange) * canvas.height;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = '#2196f3';
+    ctx.stroke();
+  }
+}

--- a/tests/test_live_chart.js
+++ b/tests/test_live_chart.js
@@ -1,0 +1,46 @@
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+import { RLTrainer } from '../src/rl/training.js';
+import { LiveChart } from '../src/ui/liveChart.js';
+
+class MockContext {
+  constructor() {
+    this.clearCount = 0;
+  }
+  clearRect() { this.clearCount++; }
+  beginPath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+}
+
+class MockCanvas {
+  constructor() {
+    this.width = 100;
+    this.height = 50;
+    this.ctx = new MockContext();
+  }
+  getContext() { return this.ctx; }
+}
+
+export async function run(assert) {
+  const env = new GridWorldEnvironment(2);
+  class StubAgent {
+    constructor() {
+      this.epsilon = 0.1;
+      this.actions = [3, 1];
+      this.i = 0;
+    }
+    act() { return this.actions[this.i++]; }
+    learn() {}
+  }
+  const agent = new StubAgent();
+  const canvas = new MockCanvas();
+  const chart = new LiveChart(canvas);
+  const trainer = new RLTrainer(agent, env, { liveChart: chart });
+  trainer.state = env.reset();
+  await trainer.step();
+  await trainer.step();
+  assert.deepStrictEqual(chart.rewards.map(v => +v.toFixed(2)), [-0.01, 0.99, 0]);
+  assert.deepStrictEqual(chart.epsilons.map(v => +v.toFixed(2)), [0.1, 0.1, 0.1]);
+  assert.strictEqual(canvas.ctx.clearCount, 3);
+}


### PR DESCRIPTION
### Context
Real-time feedback was missing while training agents, making it hard to monitor progress.

### Description
Introduces a canvas-driven live chart to plot cumulative rewards and epsilon values during training. The trainer now forwards metrics to the chart on each step.

### Changes
- Add `liveChart` canvas and import script in `index.html`.
- Implement `LiveChart` class for drawing rewards and epsilon.
- Update trainer to push metrics to `liveChart`.
- Add unit test mocking canvas to verify chart updates.

------
https://chatgpt.com/codex/tasks/task_e_68a537d4d8748332b140e4f566f016aa