### PR TITLE
feat: add SARSA agent and demo selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,14 @@
   </div>
   <canvas id="rewardChart" width="400" height="200"></canvas>
   <div>
+    <label>Agent:
+      <select id="agent-select">
+        <option value="rl">Q-learning</option>
+        <option value="sarsa">SARSA</option>
+      </select>
+    </label>
+  </div>
+  <div>
     <label>Epsilon: <input type="range" id="epsilon-slider" min="0" max="1" step="0.01" value="1"><span id="epsilon-value">1</span></label>
   </div>
   <div>
@@ -41,17 +49,25 @@
   <script type="module">
     import { GridWorldEnvironment } from './src/rl/environment.js';
     import { RLAgent } from './src/rl/agent.js';
+    import { SarsaAgent } from './src/rl/sarsaAgent.js';
     import { RLTrainer } from './src/rl/training.js';
     import { saveAgent, loadAgent } from './src/rl/storage.js';
 
     const size = 5;
     const env = new GridWorldEnvironment(size);
-    let agent = new RLAgent({ epsilon: 1, epsilonDecay: 0.995, minEpsilon: 0.05 });
+
+    function createAgent(type) {
+      const options = { epsilon: 1, epsilonDecay: 0.995, minEpsilon: 0.05 };
+      return type === 'sarsa' ? new SarsaAgent(options) : new RLAgent(options);
+    }
+
+    let agent = createAgent('rl');
     const gridEl = document.getElementById('grid');
     gridEl.style.setProperty('--size', size);
     
     const canvas = document.getElementById('rewardChart');
     const ctx = canvas.getContext('2d');
+    const agentSelect = document.getElementById('agent-select');
     const epsilonSlider = document.getElementById('epsilon-slider');
     const epsilonValue = document.getElementById('epsilon-value');
     const intervalSlider = document.getElementById('interval-slider');
@@ -98,6 +114,14 @@
     epsilonValue.textContent = agent.epsilon.toFixed(2);
     intervalSlider.value = trainer.intervalMs;
     intervalValue.textContent = trainer.intervalMs;
+
+    agentSelect.addEventListener('change', e => {
+      agent = createAgent(e.target.value);
+      trainer.agent = agent;
+      trainer.reset();
+      epsilonSlider.value = agent.epsilon;
+      epsilonValue.textContent = agent.epsilon.toFixed(2);
+    });
 
     epsilonSlider.addEventListener('input', e => {
       const val = parseFloat(e.target.value);

--- a/src/rl/sarsaAgent.js
+++ b/src/rl/sarsaAgent.js
@@ -1,0 +1,15 @@
+import { RLAgent } from './agent.js';
+
+export class SarsaAgent extends RLAgent {
+  learn(state, action, reward, nextState, done) {
+    const qVals = this._ensure(state);
+    const nextQ = this._ensure(nextState);
+    let nextAction = 0;
+    if (!done) {
+      nextAction = this.act(nextState);
+    }
+    const target = reward + (done ? 0 : this.gamma * nextQ[nextAction]);
+    qVals[action] += this.learningRate * (target - qVals[action]);
+    this.decayEpsilon();
+  }
+}

--- a/tests/test_sarsa_agent.js
+++ b/tests/test_sarsa_agent.js
@@ -1,0 +1,30 @@
+import { SarsaAgent } from '../src/rl/sarsaAgent.js';
+
+export async function run(assert) {
+  const agent = new SarsaAgent({
+    epsilon: 0,
+    learningRate: 0.5,
+    gamma: 0.9
+  });
+  const state = new Float32Array([0, 0]);
+  const nextState = new Float32Array([1, 0]);
+  const keyNext = Array.from(nextState).join(',');
+  agent.qTable.set(keyNext, new Float32Array([0, 10, 5, 0]));
+  agent.learn(state, 0, 1, nextState, false);
+  const keyState = Array.from(state).join(',');
+  const updated = agent.qTable.get(keyState)[0];
+  assert.strictEqual(updated, 5);
+
+  const decayAgent = new SarsaAgent({
+    epsilon: 1,
+    epsilonDecay: 0.5,
+    minEpsilon: 0.2
+  });
+  const s = new Float32Array([0, 0]);
+  decayAgent.learn(s, 0, 0, s, false);
+  assert.strictEqual(decayAgent.epsilon, 0.5);
+  decayAgent.learn(s, 0, 0, s, false);
+  assert.strictEqual(decayAgent.epsilon, 0.25);
+  decayAgent.learn(s, 0, 0, s, false);
+  assert.strictEqual(decayAgent.epsilon, 0.2);
+}


### PR DESCRIPTION
## Context
- Introduces on-policy SARSA learning agent
- Adds ability to choose agent type in browser demo

## Description
- Implemented `SarsaAgent` with SARSA update and epsilon decay
- Exposed option in demo to switch between Q-learning and SARSA agents
- Added unit tests to validate SARSA value updates and exploration decay

## Changes
- add `src/rl/sarsaAgent.js`
- update `index.html` demo with agent selector
- add `tests/test_sarsa_agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68a537d5b3f88332a7e43a189f3d16ac