### PR TITLE
Remove unused reward chart references

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,6 @@
     const gridEl = document.getElementById('grid');
     gridEl.style.setProperty('--size', size);
    
-    const canvas = document.getElementById('rewardChart');
-    const ctx = canvas.getContext('2d');
     const agentSelect = document.getElementById('agent-select');
     const liveChart = new LiveChart(document.getElementById('liveChart'));
     const epsilonSlider = document.getElementById('epsilon-slider');


### PR DESCRIPTION
## Context
The demo HTML referenced a reward chart canvas that no longer exists, creating unused variables.

## Description
Removed the stale rewardChart and ctx declarations so the page relies solely on the liveChart canvas.

## Changes
- Remove unused rewardChart canvas references.


------
https://chatgpt.com/codex/tasks/task_e_68a61c8e3c448332a3a0daae592f07ba