### PR TITLE
Use light grey legend and grid lines

### DIFF
--- a/src/ui/liveChart.js
+++ b/src/ui/liveChart.js
@@ -16,6 +16,18 @@ export class LiveChart {
     const { ctx, canvas, rewards, epsilons } = this;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     if (rewards.length === 0) return;
+    ctx.beginPath();
+    const gridLines = 5;
+    for (let i = 1; i < gridLines; i++) {
+      const y = (canvas.height / gridLines) * i;
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvas.width, y);
+      const x = (canvas.width / gridLines) * i;
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, canvas.height);
+    }
+    ctx.strokeStyle = '#ccc';
+    ctx.stroke();
     const maxReward = Math.max(...rewards);
     const minReward = Math.min(...rewards);
     const rewardRange = maxReward - minReward || 1;
@@ -47,13 +59,13 @@ export class LiveChart {
 
     ctx.fillStyle = '#4caf50';
     ctx.fillRect(legendX, legendY, 10, 10);
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = '#ccc';
     ctx.fillText('Reward', legendX + 15, legendY + 10);
 
     legendY += 20;
     ctx.fillStyle = '#2196f3';
     ctx.fillRect(legendX, legendY, 10, 10);
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = '#ccc';
     ctx.fillText('Epsilon', legendX + 15, legendY + 10);
   }
 }

--- a/tests/test_live_chart.js
+++ b/tests/test_live_chart.js
@@ -6,14 +6,17 @@ class MockContext {
   constructor() {
     this.clearCount = 0;
     this.texts = [];
+    this.strokeStyles = [];
+    this.fillStyle = '#000';
+    this.strokeStyle = '#000';
   }
   clearRect() { this.clearCount++; }
   beginPath() {}
   moveTo() {}
   lineTo() {}
-  stroke() {}
+  stroke() { this.strokeStyles.push(this.strokeStyle); }
   fillRect() {}
-  fillText(text) { this.texts.push(text); }
+  fillText(text) { this.texts.push({ text, style: this.fillStyle }); }
 }
 
 class MockCanvas {
@@ -46,6 +49,16 @@ export async function run(assert) {
   assert.deepStrictEqual(chart.rewards.map(v => +v.toFixed(2)), [-0.01, 0.99, 0]);
   assert.deepStrictEqual(chart.epsilons.map(v => +v.toFixed(2)), [0.1, 0.1, 0.1]);
   assert.strictEqual(canvas.ctx.clearCount, 3);
-  assert.ok(canvas.ctx.texts.includes('Reward'));
-  assert.ok(canvas.ctx.texts.includes('Epsilon'));
+  const expectedStrokes = ['#ccc', '#4caf50', '#2196f3'];
+  for (let i = 0; i < canvas.ctx.strokeStyles.length; i += 3) {
+    assert.deepStrictEqual(
+      canvas.ctx.strokeStyles.slice(i, i + 3),
+      expectedStrokes
+    );
+  }
+  const rewardEntry = canvas.ctx.texts.find(t => t.text === 'Reward');
+  const epsilonEntry = canvas.ctx.texts.find(t => t.text === 'Epsilon');
+  assert.ok(rewardEntry && epsilonEntry);
+  assert.strictEqual(rewardEntry.style, '#ccc');
+  assert.strictEqual(epsilonEntry.style, '#ccc');
 }


### PR DESCRIPTION
## Context
The live chart lacked grid lines and used dark legend text, making values harder to read.

## Description
- Render light grey grid lines on the live chart canvas.
- Display legend labels in light grey for better contrast.
- Extend unit tests to cover grid line drawing and legend text color.

## Changes
- update `LiveChart` to draw light grey grid lines and legend text
- expand `test_live_chart` to assert grid line and legend colors

------
https://chatgpt.com/codex/tasks/task_e_68a6207ae4248332baeddea40d33922e