### PR TITLE
Add Dyna-Q agent with planning updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **Grid World Environment:** Discrete environment for quick experimentation.
 - **Tabular Q-Learning Agent:** Value estimates stored in a simple lookup table.
 - **SARSA and Expected SARSA Agents:** Alternatives to standard Q-learning.
+- **Dyna-Q Agent:** Combines Q-learning with planning from a learned model.
 - **Epsilon-Greedy Exploration:** Exploration rate automatically decays during training.
 - **Episode Trainer:** Run training loops with callbacks for visualization.
 - **Pure ES6 Modules:** No build step, works with static file hosting.
@@ -39,6 +40,15 @@ await RLTrainer.trainEpisodes(agent, env, 50, 50);
 ```
 
 This repository focuses solely on reinforcement learning; previous model training utilities have been removed in favor of streamlined RL components.
+
+## Dyna-Q Planning
+
+`DynaQAgent` augments standard Q-learning with a simple model of the environment. Each real interaction stores the observed transition `(s, a) -> (s', r)`. After the real update, the agent samples a number of these stored transitions and applies additional Q-learning updates, effectively "planning" using its learned model. The number of planning iterations is configured with the `planningSteps` option.
+
+```js
+import { DynaQAgent } from './src/rl/dynaQAgent.js';
+const agent = new DynaQAgent({ planningSteps: 10 });
+```
 
 ## Saving and Loading Agents
 

--- a/src/rl/dynaQAgent.js
+++ b/src/rl/dynaQAgent.js
@@ -1,0 +1,46 @@
+import { RLAgent } from './agent.js';
+
+export class DynaQAgent extends RLAgent {
+  constructor(options = {}) {
+    super(options);
+    this.planningSteps = options.planningSteps ?? 5;
+    this.model = new Map();
+    this.stateActions = [];
+  }
+
+  _saKey(state, action) {
+    return `${this._key(state)}|${action}`;
+  }
+
+  learn(state, action, reward, nextState, done) {
+    const s = new Float32Array(state);
+    const ns = new Float32Array(nextState);
+    const key = this._saKey(s, action);
+    if (!this.model.has(key)) {
+      this.stateActions.push({ state: s, action });
+    }
+    this.model.set(key, { nextState: ns, reward, done });
+
+    const qVals = this._ensure(s);
+    const nextQ = this._ensure(ns);
+    const maxNext = done ? 0 : Math.max(...nextQ);
+    qVals[action] += this.learningRate * (reward + this.gamma * maxNext - qVals[action]);
+
+    const total = this.stateActions.length;
+    for (let i = 0; i < this.planningSteps && total > 0; i++) {
+      const idx = Math.floor(Math.random() * total);
+      const { state: ps, action: pa } = this.stateActions[idx];
+      const modelKey = this._saKey(ps, pa);
+      const modelEntry = this.model.get(modelKey);
+      const pns = modelEntry.nextState;
+      const pr = modelEntry.reward;
+      const pd = modelEntry.done;
+      const pq = this._ensure(ps);
+      const pnextQ = this._ensure(pns);
+      const pmaxNext = pd ? 0 : Math.max(...pnextQ);
+      pq[pa] += this.learningRate * (pr + this.gamma * pmaxNext - pq[pa]);
+    }
+
+    this.decayEpsilon();
+  }
+}

--- a/tests/test_dyna_q_agent.js
+++ b/tests/test_dyna_q_agent.js
@@ -1,0 +1,18 @@
+import { DynaQAgent } from '../src/rl/dynaQAgent.js';
+import { RLAgent } from '../src/rl/agent.js';
+
+export async function run(assert) {
+  const state = new Float32Array([0, 0]);
+  const nextState = new Float32Array([1, 0]);
+  const action = 2;
+
+  const base = new RLAgent({ epsilon: 0, learningRate: 0.5 });
+  base.learn(state, action, 1, nextState, false);
+  const baseVal = base.qTable.get(Array.from(state).join(','))[action];
+
+  const dyna = new DynaQAgent({ epsilon: 0, learningRate: 0.5, planningSteps: 5 });
+  dyna.learn(state, action, 1, nextState, false);
+  const dynaVal = dyna.qTable.get(Array.from(state).join(','))[action];
+
+  assert.ok(dynaVal > baseVal);
+}


### PR DESCRIPTION
## Context
- introduce model-based planning to the RL agents

## Description
- implement a Dyna-Q agent that stores transitions and performs planning updates
- allow configuring the number of planning steps
- document the planning loop

## Changes
- add `DynaQAgent` with transition model and planning loop
- test that planning updates increase Q-values beyond real experience
- describe Dyna-Q planning in README

------
https://chatgpt.com/codex/tasks/task_e_68a62d58ea888332864918cd8757817a