### PR TITLE
Add Dyna-Q agent option

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,14 @@
   <canvas id="liveChart" width="400" height="200"></canvas>
   <div>
     <label>Agent:
-      <select id="agent-select">
-        <option value="rl">Q-learning</option>
-        <option value="sarsa">SARSA</option>
-        <option value="expected">Expected SARSA</option>
-      </select>
-    </label>
-  </div>
+        <select id="agent-select">
+          <option value="rl">Q-learning</option>
+          <option value="sarsa">SARSA</option>
+          <option value="expected">Expected SARSA</option>
+          <option value="dyna">Dyna-Q</option>
+        </select>
+      </label>
+    </div>
   <div>
     <label>Epsilon: <input type="range" id="epsilon-slider" min="0" max="1" step="0.01" value="1"><span id="epsilon-value">1</span></label>
   </div>
@@ -52,6 +53,7 @@
     import { RLAgent } from './src/rl/agent.js';
     import { SarsaAgent } from './src/rl/sarsaAgent.js';
     import { ExpectedSarsaAgent } from './src/rl/expectedSarsaAgent.js';
+    import { DynaQAgent } from './src/rl/dynaQAgent.js';
     import { RLTrainer } from './src/rl/training.js';
     import { saveAgent, loadAgent } from './src/rl/storage.js';
     import { LiveChart } from './src/ui/liveChart.js';
@@ -63,6 +65,7 @@
       const options = { epsilon: 1, epsilonDecay: 0.995, minEpsilon: 0.05 };
       if (type === 'sarsa') return new SarsaAgent(options);
       if (type === 'expected') return new ExpectedSarsaAgent(options);
+      if (type === 'dyna') return new DynaQAgent(options);
       return new RLAgent(options);
     }
 

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -1,0 +1,8 @@
+import fs from 'fs';
+
+export async function run(assert) {
+  const html = fs.readFileSync('index.html', 'utf8');
+  assert.ok(html.includes('<option value="dyna">Dyna-Q</option>'));
+  assert.ok(html.includes("import { DynaQAgent } from './src/rl/dynaQAgent.js';"));
+  assert.ok(html.includes("if (type === 'dyna') return new DynaQAgent(options);"));
+}


### PR DESCRIPTION
## Context
- Include the Dyna-Q agent in the demo UI

## Description
- Expose Dyna-Q agent selection in the main demo
- Add tests ensuring the option is present and wired up

## Changes
- Add Dyna-Q entry to agent dropdown and creation logic
- Test dropdown includes Dyna-Q and uses DynaQAgent

------
https://chatgpt.com/codex/tasks/task_e_68a62f2c48908332a5bad5d9c5c8ddcb