### PR TITLE
Add TypeScript configuration for RL core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/rl/*.js
+src/rl/*.js.map
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "oblix-rl",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oblix-rl",
+      "devDependencies": {
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "pretest": "npm run build",
     "test": "node tests/run.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
   }
 }

--- a/src/rl/agent.d.ts
+++ b/src/rl/agent.d.ts
@@ -1,0 +1,31 @@
+export interface AgentOptions {
+  epsilon?: number;
+  gamma?: number;
+  learningRate?: number;
+  epsilonDecay?: number;
+  minEpsilon?: number;
+}
+export declare class RLAgent {
+  initialEpsilon: number;
+  epsilon: number;
+  gamma: number;
+  learningRate: number;
+  epsilonDecay: number;
+  minEpsilon: number;
+  qTable: Map<string, Float32Array>;
+  constructor(options?: AgentOptions);
+  protected _key(state: Float32Array): string;
+  protected _ensure(state: Float32Array): Float32Array;
+  /** Choose an action using epsilon-greedy policy. */
+  act(state: Float32Array): number;
+  /** Reduce exploration rate after learning. */
+  decayEpsilon(): void;
+  /** Perform tabular Q-learning update. */
+  learn(state: Float32Array, action: number, reward: number, nextState: Float32Array, done: boolean): void | Promise<void>;
+  /** Reset agent to initial state. */
+  reset(): void;
+  /** Serialize agent state to a plain object. */
+  toJSON(): Record<string, unknown>;
+  /** Recreate an agent from serialized data. */
+  static fromJSON(data: any): RLAgent;
+}

--- a/src/rl/agent.ts
+++ b/src/rl/agent.ts
@@ -1,5 +1,21 @@
+export interface AgentOptions {
+  epsilon?: number;
+  gamma?: number;
+  learningRate?: number;
+  epsilonDecay?: number;
+  minEpsilon?: number;
+}
+
 export class RLAgent {
-  constructor(options = {}) {
+  initialEpsilon: number;
+  epsilon: number;
+  gamma: number;
+  learningRate: number;
+  epsilonDecay: number;
+  minEpsilon: number;
+  qTable: Map<string, Float32Array>;
+
+  constructor(options: AgentOptions = {}) {
     this.initialEpsilon = options.epsilon ?? 0.1;
     this.epsilon = this.initialEpsilon;
     this.gamma = options.gamma ?? 0.95;
@@ -9,20 +25,20 @@ export class RLAgent {
     this.qTable = new Map();
   }
 
-  _key(state) {
+  protected _key(state: Float32Array): string {
     return Array.from(state).join(',');
   }
 
-  _ensure(state) {
+  protected _ensure(state: Float32Array): Float32Array {
     const key = this._key(state);
     if (!this.qTable.has(key)) {
       this.qTable.set(key, new Float32Array(4));
     }
-    return this.qTable.get(key);
+    return this.qTable.get(key)!;
   }
 
   /** Choose an action using epsilon-greedy policy. */
-  act(state) {
+  act(state: Float32Array): number {
     if (Math.random() < this.epsilon) {
       return Math.floor(Math.random() * 4);
     }
@@ -35,12 +51,18 @@ export class RLAgent {
   }
 
   /** Reduce exploration rate after learning. */
-  decayEpsilon() {
+  decayEpsilon(): void {
     this.epsilon = Math.max(this.minEpsilon, this.epsilon * this.epsilonDecay);
   }
 
   /** Perform tabular Q-learning update. */
-  learn(state, action, reward, nextState, done) {
+  learn(
+    state: Float32Array,
+    action: number,
+    reward: number,
+    nextState: Float32Array,
+    done: boolean
+  ): void | Promise<void> {
     const qVals = this._ensure(state);
     const nextQ = this._ensure(nextState);
     const maxNext = done ? 0 : Math.max(...nextQ);
@@ -50,13 +72,13 @@ export class RLAgent {
   }
 
   /** Reset agent to initial state. */
-  reset() {
+  reset(): void {
     this.epsilon = this.initialEpsilon;
     this.qTable.clear();
   }
 
   /** Serialize agent state to a plain object. */
-  toJSON() {
+  toJSON(): Record<string, unknown> {
     const table = Object.fromEntries(
       Array.from(this.qTable.entries()).map(([k, v]) => [k, Array.from(v)])
     );
@@ -66,21 +88,21 @@ export class RLAgent {
       learningRate: this.learningRate,
       epsilonDecay: this.epsilonDecay,
       minEpsilon: this.minEpsilon,
-      qTable: table,
+      qTable: table
     };
   }
 
   /** Recreate an agent from serialized data. */
-  static fromJSON(data) {
+  static fromJSON(data: any): RLAgent {
     const agent = new RLAgent({
       epsilon: data.epsilon,
       gamma: data.gamma,
       learningRate: data.learningRate,
       epsilonDecay: data.epsilonDecay,
-      minEpsilon: data.minEpsilon,
+      minEpsilon: data.minEpsilon
     });
     for (const [k, v] of Object.entries(data.qTable || {})) {
-      agent.qTable.set(k, new Float32Array(v));
+      agent.qTable.set(k, new Float32Array(v as number[]));
     }
     return agent;
   }

--- a/src/rl/dynaQAgent.d.ts
+++ b/src/rl/dynaQAgent.d.ts
@@ -1,0 +1,21 @@
+import { RLAgent, AgentOptions } from './agent.js';
+interface DynaQOptions extends AgentOptions {
+  planningSteps?: number;
+}
+interface ModelEntry {
+  nextState: Float32Array;
+  reward: number;
+  done: boolean;
+}
+export declare class DynaQAgent extends RLAgent {
+  planningSteps: number;
+  model: Map<string, ModelEntry>;
+  stateActions: {
+  state: Float32Array;
+  action: number;
+  }[];
+  constructor(options?: DynaQOptions);
+  private _saKey;
+  learn(state: Float32Array, action: number, reward: number, nextState: Float32Array, done: boolean): void | Promise<void>;
+}
+export {};

--- a/src/rl/dynaQAgent.ts
+++ b/src/rl/dynaQAgent.ts
@@ -1,18 +1,38 @@
-import { RLAgent } from './agent.js';
+import { RLAgent, AgentOptions } from './agent.js';
+
+interface DynaQOptions extends AgentOptions {
+  planningSteps?: number;
+}
+
+interface ModelEntry {
+  nextState: Float32Array;
+  reward: number;
+  done: boolean;
+}
 
 export class DynaQAgent extends RLAgent {
-  constructor(options = {}) {
+  planningSteps: number;
+  model: Map<string, ModelEntry>;
+  stateActions: { state: Float32Array; action: number }[];
+
+  constructor(options: DynaQOptions = {}) {
     super(options);
     this.planningSteps = options.planningSteps ?? 5;
     this.model = new Map();
     this.stateActions = [];
   }
 
-  _saKey(state, action) {
+  private _saKey(state: Float32Array, action: number): string {
     return `${this._key(state)}|${action}`;
   }
 
-  learn(state, action, reward, nextState, done) {
+  learn(
+    state: Float32Array,
+    action: number,
+    reward: number,
+    nextState: Float32Array,
+    done: boolean
+  ): void | Promise<void> {
     const s = new Float32Array(state);
     const ns = new Float32Array(nextState);
     const key = this._saKey(s, action);
@@ -31,7 +51,7 @@ export class DynaQAgent extends RLAgent {
       const idx = Math.floor(Math.random() * total);
       const { state: ps, action: pa } = this.stateActions[idx];
       const modelKey = this._saKey(ps, pa);
-      const modelEntry = this.model.get(modelKey);
+      const modelEntry = this.model.get(modelKey)!;
       const pns = modelEntry.nextState;
       const pr = modelEntry.reward;
       const pd = modelEntry.done;

--- a/src/rl/environment.d.ts
+++ b/src/rl/environment.d.ts
@@ -1,0 +1,33 @@
+export type EnvironmentState = Float32Array;
+export interface StepResult {
+  state: EnvironmentState;
+  reward: number;
+  done: boolean;
+}
+export declare class GridWorldEnvironment {
+  size: number;
+  obstacles: {
+  x: number;
+  y: number;
+  }[];
+  obstacleSet: Set<string>;
+  agentPos: {
+  x: number;
+  y: number;
+  };
+  constructor(size?: number, obstacles?: {
+  x: number;
+  y: number;
+  }[]);
+  /** Reset the environment to the starting state. */
+  reset(): EnvironmentState;
+  /** Convert the current agent position to state Float32Array. */
+  getState(): EnvironmentState;
+  isObstacle(x: number, y: number): boolean;
+  toggleObstacle(x: number, y: number): void;
+  /**
+   * Step the environment with an action.
+   * @param action 0:up,1:down,2:left,3:right
+   */
+  step(action: number): StepResult;
+}

--- a/src/rl/environment.ts
+++ b/src/rl/environment.ts
@@ -1,5 +1,18 @@
+export type EnvironmentState = Float32Array;
+
+export interface StepResult {
+  state: EnvironmentState;
+  reward: number;
+  done: boolean;
+}
+
 export class GridWorldEnvironment {
-  constructor(size = 5, obstacles = []) {
+  size: number;
+  obstacles: { x: number; y: number }[];
+  obstacleSet: Set<string>;
+  agentPos!: { x: number; y: number };
+
+  constructor(size = 5, obstacles: { x: number; y: number }[] = []) {
     this.size = size;
     this.obstacles = obstacles.map(o => ({ x: o.x, y: o.y }));
     this.obstacleSet = new Set(
@@ -9,21 +22,21 @@ export class GridWorldEnvironment {
   }
 
   /** Reset the environment to the starting state. */
-  reset() {
+  reset(): EnvironmentState {
     this.agentPos = { x: 0, y: 0 };
     return this.getState();
   }
 
   /** Convert the current agent position to state Float32Array. */
-  getState() {
+  getState(): EnvironmentState {
     return new Float32Array([this.agentPos.x, this.agentPos.y]);
   }
 
-  isObstacle(x, y) {
+  isObstacle(x: number, y: number): boolean {
     return this.obstacleSet.has(`${x},${y}`);
   }
 
-  toggleObstacle(x, y) {
+  toggleObstacle(x: number, y: number): void {
     const key = `${x},${y}`;
     if (this.obstacleSet.has(key)) {
       this.obstacleSet.delete(key);
@@ -36,10 +49,9 @@ export class GridWorldEnvironment {
 
   /**
    * Step the environment with an action.
-   * @param {number} action 0:up,1:down,2:left,3:right
-   * @returns {{state:Float32Array,reward:number,done:boolean}}
+   * @param action 0:up,1:down,2:left,3:right
    */
-  step(action) {
+  step(action: number): StepResult {
     let newX = this.agentPos.x;
     let newY = this.agentPos.y;
     switch (action) {

--- a/src/rl/expectedSarsaAgent.d.ts
+++ b/src/rl/expectedSarsaAgent.d.ts
@@ -1,0 +1,4 @@
+import { RLAgent } from './agent.js';
+export declare class ExpectedSarsaAgent extends RLAgent {
+  learn(state: Float32Array, action: number, reward: number, nextState: Float32Array, done: boolean): void | Promise<void>;
+}

--- a/src/rl/expectedSarsaAgent.ts
+++ b/src/rl/expectedSarsaAgent.ts
@@ -1,7 +1,13 @@
 import { RLAgent } from './agent.js';
 
 export class ExpectedSarsaAgent extends RLAgent {
-  learn(state, action, reward, nextState, done) {
+  learn(
+    state: Float32Array,
+    action: number,
+    reward: number,
+    nextState: Float32Array,
+    done: boolean
+  ): void | Promise<void> {
     const qVals = this._ensure(state);
     const nextQ = this._ensure(nextState);
     let expected = 0;

--- a/src/rl/sarsaAgent.d.ts
+++ b/src/rl/sarsaAgent.d.ts
@@ -1,0 +1,4 @@
+import { RLAgent } from './agent.js';
+export declare class SarsaAgent extends RLAgent {
+  learn(state: Float32Array, action: number, reward: number, nextState: Float32Array, done: boolean): void | Promise<void>;
+}

--- a/src/rl/sarsaAgent.ts
+++ b/src/rl/sarsaAgent.ts
@@ -1,7 +1,13 @@
 import { RLAgent } from './agent.js';
 
 export class SarsaAgent extends RLAgent {
-  learn(state, action, reward, nextState, done) {
+  learn(
+    state: Float32Array,
+    action: number,
+    reward: number,
+    nextState: Float32Array,
+    done: boolean
+  ): void | Promise<void> {
     const qVals = this._ensure(state);
     const nextQ = this._ensure(nextState);
     let nextAction = 0;

--- a/src/rl/storage.d.ts
+++ b/src/rl/storage.d.ts
@@ -1,0 +1,4 @@
+import { RLAgent } from './agent.js';
+import { RLTrainer } from './training.js';
+export declare function saveAgent(agent: RLAgent, storage?: Storage): void;
+export declare function loadAgent(trainer: RLTrainer, storage?: Storage): RLAgent;

--- a/src/rl/storage.ts
+++ b/src/rl/storage.ts
@@ -1,11 +1,18 @@
 import { RLAgent } from './agent.js';
+import { RLTrainer } from './training.js';
 
-export function saveAgent(agent, storage = globalThis.localStorage) {
+export function saveAgent(
+  agent: RLAgent,
+  storage: Storage = globalThis.localStorage
+): void {
   const data = JSON.stringify(agent.toJSON());
   storage.setItem('agent', data);
 }
 
-export function loadAgent(trainer, storage = globalThis.localStorage) {
+export function loadAgent(
+  trainer: RLTrainer,
+  storage: Storage = globalThis.localStorage
+): RLAgent {
   const data = storage.getItem('agent');
   if (!data) return trainer.agent;
   const agent = RLAgent.fromJSON(JSON.parse(data));

--- a/src/rl/training.d.ts
+++ b/src/rl/training.d.ts
@@ -1,0 +1,38 @@
+import { RLAgent } from './agent.js';
+import { GridWorldEnvironment, EnvironmentState } from './environment.js';
+export interface TrainingMetrics {
+  episode: number;
+  steps: number;
+  cumulativeReward: number;
+  epsilon: number;
+}
+export interface TrainerOptions {
+  maxSteps?: number;
+  intervalMs?: number;
+  liveChart?: {
+  push: (reward: number, epsilon: number) => void;
+  } | null;
+  onStep?: (state: EnvironmentState, reward: number, done: boolean, metrics: TrainingMetrics) => void;
+}
+export declare class RLTrainer {
+  agent: RLAgent;
+  env: GridWorldEnvironment;
+  maxSteps: number;
+  intervalMs: number;
+  liveChart: {
+  push: (reward: number, epsilon: number) => void;
+  } | null;
+  onStep: (state: EnvironmentState, reward: number, done: boolean, metrics: TrainingMetrics) => void;
+  isRunning: boolean;
+  interval: ReturnType<typeof setInterval> | null;
+  state: EnvironmentState | null;
+  metrics: TrainingMetrics;
+  episodeRewards: number[];
+  constructor(agent: RLAgent, env: GridWorldEnvironment, options?: TrainerOptions);
+  step(): Promise<void>;
+  start(): void;
+  setIntervalMs(ms: number): void;
+  pause(): void;
+  reset(): void;
+  static trainEpisodes(agent: RLAgent, env: GridWorldEnvironment, episodes?: number, maxSteps?: number): Promise<void>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/rl/**/*.ts"]
+}


### PR DESCRIPTION
## Context
- migrate reinforcement-learning core to TypeScript for stronger type safety

## Description
- add TypeScript compiler config and build step
- convert RL agent, environment, trainer, and related modules to `.ts`
- include generated type declarations

## Changes
- add `tsconfig.json`
- update npm scripts for build and tests
- rewrite `src/rl` modules in TypeScript with interfaces for options, environment state, and training metrics


------
https://chatgpt.com/codex/tasks/task_e_68a63b2189c48332afb4bbe4a063bff6