### PR TITLE
Fix DQN agent frontend loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     <button id="save">Save</button>
     <button id="load">Load</button>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.22.0/dist/tf.min.js"></script>
   <script type="module">
     import { GridWorldEnvironment } from './src/rl/environment.js';
     import { RLAgent } from './src/rl/agent.js';

--- a/src/rl/dqnAgent.js
+++ b/src/rl/dqnAgent.js
@@ -1,5 +1,11 @@
-import * as tf from '@tensorflow/tfjs';
 import { RLAgent } from './agent.js';
+
+let tf;
+try {
+  tf = await import('@tensorflow/tfjs');
+} catch {
+  tf = globalThis.tf;
+}
 
 export class DQNAgent extends RLAgent {
   constructor(options = {}) {

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -8,4 +8,5 @@ export async function run(assert) {
   assert.ok(html.includes('<option value="dqn">DQN</option>'));
   assert.ok(html.includes("import { DQNAgent } from './src/rl/dqnAgent.js';"));
   assert.ok(html.includes("if (type === 'dqn') return new DQNAgent(options);"));
+  assert.ok(html.includes('<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.22.0/dist/tf.min.js"></script>'));
 }


### PR DESCRIPTION
## Context
The DQN agent relied on a TensorFlow.js module that wasn’t available in the browser, causing the frontend to fail when selecting that agent.

## Description
- Load TensorFlow.js in the demo so the DQN agent can run in the browser
- Let the DQN agent dynamically import TensorFlow.js or use a global fallback
- Verify the presence of the TensorFlow.js script in the HTML test

## Changes
- inject TensorFlow.js script tag in `index.html`
- handle TensorFlow.js loading in `src/rl/dqnAgent.js`
- extend dropdown test for the new script reference

------
https://chatgpt.com/codex/tasks/task_e_68a7d5103c78833291fb35d067807f71