### PR TITLE
feat: enhance live chart visualization

### DIFF
--- a/src/ui/liveChart.js
+++ b/src/ui/liveChart.js
@@ -1,25 +1,39 @@
 export class LiveChart {
-  constructor(canvas, windowSize = 10) {
+  constructor(canvas, windowSize = 0) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
-    this.windowSize = windowSize;
+    this.movingAvgWindow = windowSize;
     this.rewards = [];
     this.epsilons = [];
     this.avgRewards = [];
+    this.resize = this.resize.bind(this);
+    this.resize();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', this.resize);
+    }
   }
 
   push(reward, epsilon) {
     this.rewards.push(reward);
     this.epsilons.push(epsilon);
-    const start = Math.max(0, this.rewards.length - this.windowSize);
-    const slice = this.rewards.slice(start);
-    const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
-    this.avgRewards.push(avg);
+    if (this.movingAvgWindow > 1) {
+      const start = Math.max(0, this.rewards.length - this.movingAvgWindow);
+      const slice = this.rewards.slice(start);
+      const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
+      this.avgRewards.push(avg);
+    }
+    this.draw();
+  }
+
+  resize() {
+    if (this.canvas.parentElement) {
+      this.canvas.width = this.canvas.parentElement.clientWidth;
+    }
     this.draw();
   }
 
   draw() {
-    const { ctx, canvas, rewards, epsilons, avgRewards } = this;
+    const { ctx, canvas, rewards, epsilons, avgRewards, movingAvgWindow } = this;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     if (rewards.length === 0) return;
     ctx.beginPath();
@@ -34,10 +48,52 @@ export class LiveChart {
     }
     ctx.strokeStyle = '#ccc';
     ctx.stroke();
+
     const maxReward = Math.max(...rewards);
     const minReward = Math.min(...rewards);
     const rewardRange = maxReward - minReward || 1;
     const stepX = canvas.width / Math.max(rewards.length - 1, 1);
+
+    ctx.beginPath();
+    ctx.moveTo(0, canvas.height);
+    ctx.lineTo(canvas.width, canvas.height);
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, canvas.height);
+
+    const xTicks = 5;
+    const xStepEpisodes = Math.max(1, Math.floor((rewards.length - 1) / xTicks));
+    for (let i = 0; i <= rewards.length - 1; i += xStepEpisodes) {
+      const x = i * stepX;
+      ctx.moveTo(x, canvas.height);
+      ctx.lineTo(x, canvas.height - 5);
+    }
+
+    const yTicks = 5;
+    for (let i = 0; i <= yTicks; i++) {
+      const value = minReward + (rewardRange * i) / yTicks;
+      const y = canvas.height - ((value - minReward) / rewardRange) * canvas.height;
+      ctx.moveTo(0, y);
+      ctx.lineTo(5, y);
+    }
+    ctx.strokeStyle = '#999';
+    ctx.stroke();
+
+    ctx.fillStyle = '#ccc';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    for (let i = 0; i <= rewards.length - 1; i += xStepEpisodes) {
+      const x = i * stepX;
+      ctx.fillText(String(i), x, canvas.height - 7);
+    }
+
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    for (let i = 0; i <= yTicks; i++) {
+      const value = minReward + (rewardRange * i) / yTicks;
+      const y = canvas.height - ((value - minReward) / rewardRange) * canvas.height;
+      ctx.fillText(value.toFixed(2), 10, y);
+    }
+
     ctx.beginPath();
     rewards.forEach((r, i) => {
       const x = i * stepX;
@@ -48,15 +104,17 @@ export class LiveChart {
     ctx.strokeStyle = '#4caf50';
     ctx.stroke();
 
-    ctx.beginPath();
-    avgRewards.forEach((r, i) => {
-      const x = i * stepX;
-      const y = canvas.height - ((r - minReward) / rewardRange) * canvas.height;
-      if (i === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
-    });
-    ctx.strokeStyle = '#ff9800';
-    ctx.stroke();
+    if (movingAvgWindow > 1 && avgRewards.length > 0) {
+      ctx.beginPath();
+      avgRewards.forEach((r, i) => {
+        const x = i * stepX;
+        const y = canvas.height - ((r - minReward) / rewardRange) * canvas.height;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.strokeStyle = '#ff9800';
+      ctx.stroke();
+    }
 
     const epsRange = 1;
     ctx.beginPath();
@@ -78,11 +136,13 @@ export class LiveChart {
     ctx.fillStyle = '#ccc';
     ctx.fillText('Reward', legendX + 15, legendY + 10);
 
-    legendY += 20;
-    ctx.fillStyle = '#ff9800';
-    ctx.fillRect(legendX, legendY, 10, 10);
-    ctx.fillStyle = '#ccc';
-    ctx.fillText('Avg Reward', legendX + 15, legendY + 10);
+    if (movingAvgWindow > 1) {
+      legendY += 20;
+      ctx.fillStyle = '#ff9800';
+      ctx.fillRect(legendX, legendY, 10, 10);
+      ctx.fillStyle = '#ccc';
+      ctx.fillText('Avg Reward', legendX + 15, legendY + 10);
+    }
 
     legendY += 20;
     ctx.fillStyle = '#2196f3';

--- a/tests/test_live_chart.js
+++ b/tests/test_live_chart.js
@@ -49,11 +49,11 @@ export async function run(assert) {
   assert.deepStrictEqual(chart.rewards.map(v => +v.toFixed(2)), [-0.01, 0.99, 0]);
   assert.deepStrictEqual(chart.avgRewards.map(v => +v.toFixed(2)), [-0.01, 0.49, 0.49]);
   assert.deepStrictEqual(chart.epsilons.map(v => +v.toFixed(2)), [0.1, 0.1, 0.1]);
-  assert.strictEqual(canvas.ctx.clearCount, 3);
-  const expectedStrokes = ['#ccc', '#4caf50', '#ff9800', '#2196f3'];
-  for (let i = 0; i < canvas.ctx.strokeStyles.length; i += 4) {
+  assert.strictEqual(canvas.ctx.clearCount, 4);
+  const expectedStrokes = ['#ccc', '#999', '#4caf50', '#ff9800', '#2196f3'];
+  for (let i = 0; i < canvas.ctx.strokeStyles.length; i += 5) {
     assert.deepStrictEqual(
-      canvas.ctx.strokeStyles.slice(i, i + 4),
+      canvas.ctx.strokeStyles.slice(i, i + 5),
       expectedStrokes
     );
   }
@@ -64,4 +64,10 @@ export async function run(assert) {
   assert.strictEqual(rewardEntry.style, '#ccc');
   assert.strictEqual(avgEntry.style, '#ccc');
   assert.strictEqual(epsilonEntry.style, '#ccc');
+
+  const tickTexts = canvas.ctx.texts.filter(t =>
+    /^[-\d]/.test(t.text) &&
+    !['Reward', 'Avg Reward', 'Epsilon'].includes(t.text)
+  );
+  assert.ok(tickTexts.length > 0);
 }


### PR DESCRIPTION
## Context
- improve training chart readability and responsiveness

## Description
- add axes with tick labels and optional moving-average line
- resize canvas with its container and redraw on window resize
- extend tests to check axes and moving-average rendering

## Changes
- update `LiveChart` to support responsive canvas and configurable moving average
- render x/y axes with ticks and labels
- revise live chart unit test for new visuals


------
https://chatgpt.com/codex/tasks/task_e_68abe30d93288332ab621564755f6f6c