### PR TITLE
Extract inline styles into stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>oblix-rl demo</title>
-  <style>
-    body { font-family: sans-serif; text-align: center; background: #1e1e1e; color: #eee; }
-    #grid { display: grid; margin: 20px auto; grid-template-columns: repeat(var(--size), 40px); width: fit-content; }
-    .cell { width: 40px; height: 40px; border: 1px solid #555; }
-    .agent { background: #4caf50; }
-    .goal { background: #2196f3; }
-    .obstacle { background: #f44336; }
-    button { margin: 5px; padding: 8px 16px; border: none; background: #444; color: #fff; cursor: pointer; }
-    button:hover { background: #666; }
-    canvas { background: #222; border: 1px solid #555; }
-  </style>
+  <link rel="stylesheet" href="./src/ui/styles.css">
 </head>
 <body>
   <h1>oblix-rl Grid World</h1>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,0 +1,50 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+  background: #1e1e1e;
+  color: #eee;
+}
+
+#grid {
+  display: grid;
+  margin: 20px auto;
+  grid-template-columns: repeat(var(--size), 40px);
+  width: fit-content;
+}
+
+.cell {
+  width: 40px;
+  height: 40px;
+  border: 1px solid #555;
+}
+
+.agent {
+  background: #4caf50;
+}
+
+.goal {
+  background: #2196f3;
+}
+
+.obstacle {
+  background: #f44336;
+}
+
+button {
+  margin: 5px;
+  padding: 8px 16px;
+  border: none;
+  background: #444;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #666;
+}
+
+canvas {
+  background: #222;
+  border: 1px solid #555;
+}
+


### PR DESCRIPTION
## Context
Moves page styles into a dedicated stylesheet for better organization.

## Description
- remove inline style block from index.html
- add styles.css under src/ui and link it in index.html

## Changes
- migrated existing style rules into new src/ui/styles.css
- updated index.html to load the external stylesheet


------
https://chatgpt.com/codex/tasks/task_e_68abe620d400833282ca260dbf8d5b7c