### PR TITLE
feat: add policy selection options

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,15 @@
       </label>
     </div>
   <div>
+    <label>Policy:
+        <select id="policy-select">
+          <option value="epsilon-greedy">Epsilon-Greedy</option>
+          <option value="greedy">Greedy</option>
+          <option value="softmax">Softmax</option>
+        </select>
+      </label>
+    </div>
+  <div>
     <label>Epsilon: <input type="range" id="epsilon-slider" min="0" max="1" step="0.01" value="1"><span id="epsilon-value">1</span></label>
   </div>
   <div>

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -10,8 +10,10 @@ import { LiveChart } from './liveChart.js';
 const size = 5;
 const env = new GridWorldEnvironment(size);
 
+const policySelect = document.getElementById('policy-select');
+
 function createAgent(type) {
-  const options = { epsilon: 1, epsilonDecay: 0.995, minEpsilon: 0.05 };
+  const options = { epsilon: 1, epsilonDecay: 0.995, minEpsilon: 0.05, policy: policySelect.value };
   if (type === 'sarsa') return new SarsaAgent(options);
   if (type === 'expected') return new ExpectedSarsaAgent(options);
   if (type === 'dyna') return new DynaQAgent(options);
@@ -73,6 +75,7 @@ const trainer = new RLTrainer(agent, env, {
 
 epsilonSlider.value = agent.epsilon;
 epsilonValue.textContent = agent.epsilon.toFixed(2);
+policySelect.value = agent.policy;
 intervalSlider.value = trainer.intervalMs;
 intervalValue.textContent = trainer.intervalMs;
 syncLearningRate();
@@ -83,7 +86,12 @@ agentSelect.addEventListener('change', e => {
   trainer.reset();
   epsilonSlider.value = agent.epsilon;
   epsilonValue.textContent = agent.epsilon.toFixed(2);
+  policySelect.value = agent.policy;
   syncLearningRate();
+});
+
+policySelect.addEventListener('change', e => {
+  agent.policy = e.target.value;
 });
 
 epsilonSlider.addEventListener('input', e => {
@@ -119,6 +127,7 @@ document.getElementById('load').onclick = () => {
   agent = loadAgent(trainer);
   epsilonSlider.value = agent.epsilon;
   epsilonValue.textContent = agent.epsilon.toFixed(2);
+  policySelect.value = agent.policy;
   syncLearningRate();
   render(trainer.state);
 };

--- a/tests/test_policies.js
+++ b/tests/test_policies.js
@@ -1,0 +1,19 @@
+import { RLAgent } from '../src/rl/agent.js';
+
+export async function run(assert) {
+  const state = new Float32Array([0, 0]);
+  const key = Array.from(state).join(',');
+
+  const greedyAgent = new RLAgent({ epsilon: 1, policy: 'greedy' });
+  greedyAgent.qTable.set(key, new Float32Array([1, 5, 3, 2]));
+  assert.strictEqual(greedyAgent.act(state), 1);
+
+  const softAgent = new RLAgent({ policy: 'softmax', temperature: 1 });
+  softAgent.qTable.set(key, new Float32Array([1, 5, 1, 1]));
+  const origRandom = Math.random;
+  Math.random = () => 0.5;
+  assert.strictEqual(softAgent.act(state), 1);
+  Math.random = () => 0;
+  assert.strictEqual(softAgent.act(state), 0);
+  Math.random = origRandom;
+}


### PR DESCRIPTION
## Context
- expand action-selection strategies beyond epsilon-greedy

## Description
- add greedy and softmax policies and expose them via a new dropdown
- support policy persistence and selection in UI
- cover policies with tests

## Changes
- introduce policy handling in `RLAgent`
- add policy dropdown in `index.html` and logic in `src/ui/index.js`
- create `tests/test_policies.js`


------
https://chatgpt.com/codex/tasks/task_e_68abe9c65dcc8332a0d81aa64b2d5f08