### PR TITLE
Add UCB policy option

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
           <option value="epsilon-greedy">Epsilon-Greedy</option>
           <option value="greedy">Greedy</option>
           <option value="softmax">Softmax</option>
+          <option value="ucb">UCB</option>
         </select>
       </label>
     </div>

--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -26,7 +26,7 @@ export class RLAgent {
   }
 
   /** Choose an action using the configured policy. */
-  act(state) {
+  act(state, update = true) {
     const qVals = this._ensure(state);
     switch (this.policy) {
       case 'greedy':
@@ -34,7 +34,7 @@ export class RLAgent {
       case 'softmax':
         return this._softmax(qVals);
       case 'ucb':
-        return this._ucb(state, qVals);
+        return this._ucb(state, qVals, update);
       case 'epsilon-greedy':
       default:
         return this._epsilonGreedy(qVals);
@@ -80,11 +80,11 @@ export class RLAgent {
     return this.countTable.get(key);
   }
 
-  _ucb(state, qVals) {
+  _ucb(state, qVals, update) {
     const counts = this._ensureCount(state);
     for (let i = 0; i < counts.length; i++) {
       if (counts[i] === 0) {
-        counts[i]++;
+        if (update) counts[i]++;
         return i;
       }
     }
@@ -98,7 +98,7 @@ export class RLAgent {
         best = i;
       }
     }
-    counts[best]++;
+    if (update) counts[best]++;
     return best;
   }
 

--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -8,7 +8,9 @@ export class RLAgent {
     this.minEpsilon = options.minEpsilon ?? 0.01;
     this.policy = options.policy ?? 'epsilon-greedy';
     this.temperature = options.temperature ?? 1;
+    this.ucbC = options.ucbC ?? 2;
     this.qTable = new Map();
+    this.countTable = new Map();
   }
 
   _key(state) {
@@ -31,6 +33,8 @@ export class RLAgent {
         return this._greedy(qVals);
       case 'softmax':
         return this._softmax(qVals);
+      case 'ucb':
+        return this._ucb(state, qVals);
       case 'epsilon-greedy':
       default:
         return this._epsilonGreedy(qVals);
@@ -68,6 +72,36 @@ export class RLAgent {
     return exps.length - 1;
   }
 
+  _ensureCount(state) {
+    const key = this._key(state);
+    if (!this.countTable.has(key)) {
+      this.countTable.set(key, new Uint32Array(4));
+    }
+    return this.countTable.get(key);
+  }
+
+  _ucb(state, qVals) {
+    const counts = this._ensureCount(state);
+    for (let i = 0; i < counts.length; i++) {
+      if (counts[i] === 0) {
+        counts[i]++;
+        return i;
+      }
+    }
+    const total = counts.reduce((a, b) => a + b, 0);
+    let best = 0;
+    let bestScore = -Infinity;
+    for (let i = 0; i < qVals.length; i++) {
+      const score = qVals[i] + this.ucbC * Math.sqrt(Math.log(total) / counts[i]);
+      if (score > bestScore) {
+        bestScore = score;
+        best = i;
+      }
+    }
+    counts[best]++;
+    return best;
+  }
+
   /** Reduce exploration rate after learning. */
   decayEpsilon() {
     this.epsilon = Math.max(this.minEpsilon, this.epsilon * this.epsilonDecay);
@@ -86,12 +120,16 @@ export class RLAgent {
   reset() {
     this.epsilon = this.initialEpsilon;
     this.qTable.clear();
+    this.countTable.clear();
   }
 
   /** Serialize agent state to a plain object. */
   toJSON() {
     const table = Object.fromEntries(
       Array.from(this.qTable.entries()).map(([k, v]) => [k, Array.from(v)])
+    );
+    const counts = Object.fromEntries(
+      Array.from(this.countTable.entries()).map(([k, v]) => [k, Array.from(v)])
     );
     return {
       epsilon: this.epsilon,
@@ -101,7 +139,9 @@ export class RLAgent {
       minEpsilon: this.minEpsilon,
       policy: this.policy,
       temperature: this.temperature,
-      qTable: table
+      ucbC: this.ucbC,
+      qTable: table,
+      countTable: counts
     };
   }
 
@@ -114,10 +154,14 @@ export class RLAgent {
       epsilonDecay: data.epsilonDecay,
       minEpsilon: data.minEpsilon,
       policy: data.policy,
-      temperature: data.temperature
+      temperature: data.temperature,
+      ucbC: data.ucbC
     });
     for (const [k, v] of Object.entries(data.qTable || {})) {
       agent.qTable.set(k, new Float32Array(v));
+    }
+    for (const [k, v] of Object.entries(data.countTable || {})) {
+      agent.countTable.set(k, new Uint32Array(v));
     }
     return agent;
   }

--- a/src/rl/sarsaAgent.js
+++ b/src/rl/sarsaAgent.js
@@ -6,7 +6,7 @@ export class SarsaAgent extends RLAgent {
     const nextQ = this._ensure(nextState);
     let nextAction = 0;
     if (!done) {
-      nextAction = this.act(nextState);
+      nextAction = this.act(nextState, false);
     }
     const target = reward + (done ? 0 : this.gamma * nextQ[nextAction]);
     qVals[action] += this.learningRate * (target - qVals[action]);

--- a/tests/test_policies.js
+++ b/tests/test_policies.js
@@ -19,6 +19,7 @@ export async function run(assert) {
 
   const ucbAgent = new RLAgent({ policy: 'ucb', ucbC: 1 });
   ucbAgent.qTable.set(key, new Float32Array([1, 5, 3, 2]));
+  assert.strictEqual(ucbAgent.act(state, false), 0);
   assert.strictEqual(ucbAgent.act(state), 0);
   assert.strictEqual(ucbAgent.act(state), 1);
   assert.strictEqual(ucbAgent.act(state), 2);

--- a/tests/test_policies.js
+++ b/tests/test_policies.js
@@ -16,4 +16,12 @@ export async function run(assert) {
   Math.random = () => 0;
   assert.strictEqual(softAgent.act(state), 0);
   Math.random = origRandom;
+
+  const ucbAgent = new RLAgent({ policy: 'ucb', ucbC: 1 });
+  ucbAgent.qTable.set(key, new Float32Array([1, 5, 3, 2]));
+  assert.strictEqual(ucbAgent.act(state), 0);
+  assert.strictEqual(ucbAgent.act(state), 1);
+  assert.strictEqual(ucbAgent.act(state), 2);
+  assert.strictEqual(ucbAgent.act(state), 3);
+  assert.strictEqual(ucbAgent.act(state), 1);
 }


### PR DESCRIPTION
## Context
Introduces UCB sampling as an additional agent policy.

## Description
- Implement UCB policy with action visit tracking and serialization.
- Expose UCB in the policy dropdown for the demo UI.
- Test UCB behavior alongside existing policies.

## Changes
- Extend RLAgent with UCB logic and persistence support.
- Update interface to offer UCB as a policy option.
- Add unit test for the UCB policy.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b11b4c4d448332b4d17ebfead6b697