### PR TITLE
Add Thompson sampling policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
           <option value="greedy">Greedy</option>
           <option value="softmax">Softmax</option>
           <option value="ucb">UCB</option>
+          <option value="thompson">Thompson Sampling</option>
         </select>
       </label>
     </div>

--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -33,6 +33,8 @@ export class RLAgent {
         return this._greedy(qVals);
       case 'softmax':
         return this._softmax(qVals);
+      case 'thompson':
+        return this._thompson(state, qVals, update);
       case 'ucb':
         return this._ucb(state, qVals, update);
       case 'epsilon-greedy':
@@ -70,6 +72,30 @@ export class RLAgent {
       if (r <= 0) return i;
     }
     return exps.length - 1;
+  }
+
+  _gaussian() {
+    let u = 0;
+    let v = 0;
+    while (u === 0) u = Math.random();
+    while (v === 0) v = Math.random();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+  }
+
+  _thompson(state, qVals, update) {
+    const counts = this._ensureCount(state);
+    let best = 0;
+    let bestSample = -Infinity;
+    for (let i = 0; i < qVals.length; i++) {
+      const variance = 1 / (counts[i] + 1);
+      const sample = qVals[i] + this._gaussian() * Math.sqrt(variance);
+      if (sample > bestSample) {
+        bestSample = sample;
+        best = i;
+      }
+    }
+    if (update) counts[best]++;
+    return best;
   }
 
   _ensureCount(state) {

--- a/tests/test_policies.js
+++ b/tests/test_policies.js
@@ -25,4 +25,10 @@ export async function run(assert) {
   assert.strictEqual(ucbAgent.act(state), 2);
   assert.strictEqual(ucbAgent.act(state), 3);
   assert.strictEqual(ucbAgent.act(state), 1);
+
+  const thompAgent = new RLAgent({ policy: 'thompson' });
+  thompAgent.qTable.set(key, new Float32Array([1, 5, 3, 2]));
+  thompAgent._gaussian = () => 0;
+  assert.strictEqual(thompAgent.act(state), 1);
+  assert.strictEqual(thompAgent.countTable.get(key)[1], 1);
 }


### PR DESCRIPTION
## Context
- expand available exploration strategies

## Description
- implement Thompson sampling policy
- expose Thompson sampling in policy selection dropdown
- cover policy with new unit test

## Changes
- add Thompson sampling algorithm to RLAgent
- update interface to allow selecting Thompson sampling
- verify Thompson sampling behavior with tests

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b11ec042808332905f5db858ff4c39