### PR TITLE
Add Q(lambda) agent with eligibility traces

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <label>Agent:
         <select id="agent-select">
           <option value="rl">Q-learning</option>
+          <option value="qlambda">Q(&lambda;)</option>
           <option value="sarsa">SARSA</option>
           <option value="expected">Expected SARSA</option>
           <option value="dyna">Dyna-Q</option>
@@ -41,6 +42,9 @@
   </div>
   <div>
     <label>Learning Rate: <input type="range" id="learning-rate-slider" min="0" max="1" step="0.01" value="0.1"><span id="learning-rate-value">0.10</span></label>
+  </div>
+  <div>
+    <label>Lambda: <input type="range" id="lambda-slider" min="0" max="1" step="0.01" value="0.9"><span id="lambda-value">0.90</span></label>
   </div>
   <div>
     <label>Interval (ms): <input type="range" id="interval-slider" min="10" max="1000" step="10" value="100"><span id="interval-value">100</span></label>

--- a/src/rl/qLambdaAgent.js
+++ b/src/rl/qLambdaAgent.js
@@ -1,0 +1,67 @@
+import { RLAgent } from './agent.js';
+
+export class QLambdaAgent extends RLAgent {
+  constructor(options = {}) {
+    super(options);
+    this.lambda = options.lambda ?? 0.8;
+    this.eligibility = new Map();
+  }
+
+  _ensureEligibility(state) {
+    const key = this._key(state);
+    if (!this.eligibility.has(key)) {
+      this.eligibility.set(key, new Float32Array(4));
+    }
+    return this.eligibility.get(key);
+  }
+
+  learn(state, action, reward, nextState, done) {
+    const qVals = this._ensure(state);
+    const nextQ = this._ensure(nextState);
+    const elig = this._ensureEligibility(state);
+    elig[action] += 1;
+    const target = reward + (done ? 0 : this.gamma * Math.max(...nextQ));
+    const delta = target - qVals[action];
+    for (const [key, eVals] of this.eligibility.entries()) {
+      const q = this.qTable.get(key);
+      for (let i = 0; i < eVals.length; i++) {
+        q[i] += this.learningRate * delta * eVals[i];
+        eVals[i] *= this.lambda * this.gamma;
+      }
+    }
+    if (done) this.eligibility.clear();
+    this.decayEpsilon();
+  }
+
+  reset() {
+    super.reset();
+    this.eligibility.clear();
+  }
+
+  toJSON() {
+    const data = super.toJSON();
+    data.lambda = this.lambda;
+    return data;
+  }
+
+  static fromJSON(data) {
+    const agent = new QLambdaAgent({
+      epsilon: data.epsilon,
+      gamma: data.gamma,
+      learningRate: data.learningRate,
+      epsilonDecay: data.epsilonDecay,
+      minEpsilon: data.minEpsilon,
+      policy: data.policy,
+      temperature: data.temperature,
+      ucbC: data.ucbC,
+      lambda: data.lambda
+    });
+    for (const [k, v] of Object.entries(data.qTable || {})) {
+      agent.qTable.set(k, new Float32Array(v));
+    }
+    for (const [k, v] of Object.entries(data.countTable || {})) {
+      agent.countTable.set(k, new Uint32Array(v));
+    }
+    return agent;
+  }
+}

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -3,6 +3,7 @@ import { RLAgent } from '../rl/agent.js';
 import { SarsaAgent } from '../rl/sarsaAgent.js';
 import { ExpectedSarsaAgent } from '../rl/expectedSarsaAgent.js';
 import { DynaQAgent } from '../rl/dynaQAgent.js';
+import { QLambdaAgent } from '../rl/qLambdaAgent.js';
 import { RLTrainer } from '../rl/training.js';
 import { saveAgent, loadAgent } from '../rl/storage.js';
 import { LiveChart } from './liveChart.js';
@@ -11,12 +12,21 @@ const size = 5;
 const env = new GridWorldEnvironment(size);
 
 const policySelect = document.getElementById('policy-select');
+const lambdaSlider = document.getElementById('lambda-slider');
+const lambdaValue = document.getElementById('lambda-value');
 
 function createAgent(type) {
-  const options = { epsilon: 1, epsilonDecay: 0.995, minEpsilon: 0.05, policy: policySelect.value };
+  const options = {
+    epsilon: 1,
+    epsilonDecay: 0.995,
+    minEpsilon: 0.05,
+    policy: policySelect.value,
+    lambda: parseFloat(lambdaSlider.value)
+  };
   if (type === 'sarsa') return new SarsaAgent(options);
   if (type === 'expected') return new ExpectedSarsaAgent(options);
   if (type === 'dyna') return new DynaQAgent(options);
+  if (type === 'qlambda') return new QLambdaAgent(options);
   return new RLAgent(options);
 }
 
@@ -36,6 +46,12 @@ const learningRateValue = document.getElementById('learning-rate-value');
 function syncLearningRate() {
   learningRateSlider.value = agent.learningRate;
   learningRateValue.textContent = agent.learningRate.toFixed(2);
+}
+
+function syncLambda() {
+  lambdaSlider.value = agent.lambda ?? parseFloat(lambdaSlider.value);
+  const val = parseFloat(lambdaSlider.value);
+  lambdaValue.textContent = val.toFixed(2);
 }
 
 function render(state) {
@@ -79,6 +95,7 @@ policySelect.value = agent.policy;
 intervalSlider.value = trainer.intervalMs;
 intervalValue.textContent = trainer.intervalMs;
 syncLearningRate();
+syncLambda();
 
 agentSelect.addEventListener('change', e => {
   agent = createAgent(e.target.value);
@@ -88,6 +105,7 @@ agentSelect.addEventListener('change', e => {
   epsilonValue.textContent = agent.epsilon.toFixed(2);
   policySelect.value = agent.policy;
   syncLearningRate();
+  syncLambda();
 });
 
 policySelect.addEventListener('change', e => {
@@ -112,6 +130,12 @@ learningRateSlider.addEventListener('input', e => {
   const val = parseFloat(e.target.value);
   agent.learningRate = val;
   learningRateValue.textContent = val.toFixed(2);
+});
+
+lambdaSlider.addEventListener('input', e => {
+  const val = parseFloat(e.target.value);
+  agent.lambda = val;
+  lambdaValue.textContent = val.toFixed(2);
 });
 
 document.getElementById('start').onclick = () => trainer.start();

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -6,6 +6,9 @@ export async function run(assert) {
   assert.ok(html.includes('<option value="dyna">Dyna-Q</option>'));
   assert.ok(js.includes("import { DynaQAgent } from '../rl/dynaQAgent.js';"));
   assert.ok(js.includes("if (type === 'dyna') return new DynaQAgent(options);"));
+  assert.ok(html.includes('<option value="qlambda">Q(&lambda;)</option>'));
+  assert.ok(js.includes("import { QLambdaAgent } from '../rl/qLambdaAgent.js';"));
+  assert.ok(js.includes("if (type === 'qlambda') return new QLambdaAgent(options);"));
   assert.ok(!html.includes('<option value="dqn">'));
   assert.ok(!html.includes('@tensorflow/tfjs'));
   assert.ok(!js.includes('@tensorflow/tfjs'));

--- a/tests/test_q_lambda_agent.js
+++ b/tests/test_q_lambda_agent.js
@@ -1,0 +1,18 @@
+import { RLAgent } from '../src/rl/agent.js';
+import { QLambdaAgent } from '../src/rl/qLambdaAgent.js';
+
+export async function run(assert) {
+  const rl = new RLAgent({ epsilon: 0, learningRate: 0.5, gamma: 0.9 });
+  const ql = new QLambdaAgent({ epsilon: 0, learningRate: 0.5, gamma: 0.9, lambda: 0.8 });
+  const s0 = new Float32Array([0, 0]);
+  const s1 = new Float32Array([1, 0]);
+  const s2 = new Float32Array([2, 0]);
+  rl.learn(s0, 3, -0.01, s1, false);
+  ql.learn(s0, 3, -0.01, s1, false);
+  rl.learn(s1, 3, 1, s2, true);
+  ql.learn(s1, 3, 1, s2, true);
+  const key = Array.from(s0).join(',');
+  const rlVal = rl.qTable.get(key)[3];
+  const qlVal = ql.qTable.get(key)[3];
+  assert.ok(qlVal > rlVal);
+}


### PR DESCRIPTION
## Context
- Introduces Q(λ) agent to accelerate learning with eligibility traces.
- Extends UI to configure λ and choose the agent.

## Description
- Implements QLambdaAgent that tracks state-action eligibility decaying by λγ each step and updates all traces during learning.
- Adds lambda controls and agent option in the demo interface.
- Adds tests comparing convergence speed to baseline RLAgent.

## Changes
- Add `qLambdaAgent.js` implementing Q(λ).
- Update UI and HTML to support selecting agent and tuning λ.
- Add unit tests for agent and dropdown.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b30939f3088332939f3a2841697092