### PR TITLE
Add Monte Carlo agent with value estimation tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <label>Agent:
         <select id="agent-select">
           <option value="rl">Q-learning</option>
+          <option value="mc">Monte Carlo</option>
           <option value="qlambda">Q(&lambda;)</option>
           <option value="sarsa">SARSA</option>
           <option value="expected">Expected SARSA</option>

--- a/src/rl/monteCarloAgent.js
+++ b/src/rl/monteCarloAgent.js
@@ -1,0 +1,54 @@
+import { RLAgent } from './agent.js';
+
+export class MonteCarloAgent extends RLAgent {
+  constructor(options = {}) {
+    super(options);
+    this.exploringStarts = options.exploringStarts ?? false;
+    this.episode = [];
+  }
+
+  act(state, update = true) {
+    if (this.exploringStarts && this.episode.length === 0) {
+      return this._random();
+    }
+    return super.act(state, update);
+  }
+
+  learn(state, action, reward, nextState, done) {
+    this.episode.push({
+      state: new Float32Array(state),
+      key: this._key(state),
+      action,
+      reward
+    });
+    if (done) {
+      let G = 0;
+      for (let i = this.episode.length - 1; i >= 0; i--) {
+        const step = this.episode[i];
+        G = step.reward + this.gamma * G;
+        let firstVisit = true;
+        for (let j = 0; j < i; j++) {
+          const prev = this.episode[j];
+          if (prev.key === step.key && prev.action === step.action) {
+            firstVisit = false;
+            break;
+          }
+        }
+        if (firstVisit) {
+          const qVals = this._ensure(step.state);
+          const counts = this._ensureCount(step.state);
+          counts[step.action] += 1;
+          qVals[step.action] += (G - qVals[step.action]) / counts[step.action];
+        }
+      }
+      this.episode = [];
+      this.decayEpsilon();
+    }
+  }
+
+  reset() {
+    super.reset();
+    this.episode = [];
+  }
+}
+

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -4,6 +4,7 @@ import { SarsaAgent } from '../rl/sarsaAgent.js';
 import { ExpectedSarsaAgent } from '../rl/expectedSarsaAgent.js';
 import { DynaQAgent } from '../rl/dynaQAgent.js';
 import { QLambdaAgent } from '../rl/qLambdaAgent.js';
+import { MonteCarloAgent } from '../rl/monteCarloAgent.js';
 import { RLTrainer } from '../rl/training.js';
 import { saveAgent, loadAgent } from '../rl/storage.js';
 import { LiveChart } from './liveChart.js';
@@ -27,6 +28,7 @@ function createAgent(type) {
   if (type === 'expected') return new ExpectedSarsaAgent(options);
   if (type === 'dyna') return new DynaQAgent(options);
   if (type === 'qlambda') return new QLambdaAgent(options);
+  if (type === 'mc') return new MonteCarloAgent(options);
   return new RLAgent(options);
 }
 

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -3,6 +3,9 @@ import fs from 'fs';
 export async function run(assert) {
   const html = fs.readFileSync('index.html', 'utf8');
   const js = fs.readFileSync('src/ui/index.js', 'utf8');
+  assert.ok(html.includes('<option value="mc">Monte Carlo</option>'));
+  assert.ok(js.includes("import { MonteCarloAgent } from '../rl/monteCarloAgent.js';"));
+  assert.ok(js.includes("if (type === 'mc') return new MonteCarloAgent(options);"));
   assert.ok(html.includes('<option value="dyna">Dyna-Q</option>'));
   assert.ok(js.includes("import { DynaQAgent } from '../rl/dynaQAgent.js';"));
   assert.ok(js.includes("if (type === 'dyna') return new DynaQAgent(options);"));

--- a/tests/test_monte_carlo_agent.js
+++ b/tests/test_monte_carlo_agent.js
@@ -1,0 +1,23 @@
+import { MonteCarloAgent } from '../src/rl/monteCarloAgent.js';
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+
+export async function run(assert) {
+  const env = new GridWorldEnvironment(2);
+  const agent = new MonteCarloAgent({ gamma: 1, epsilon: 0 });
+  const expectedFirst = -0.01 + 1;
+  const expectedSecond = 1;
+  for (let i = 0; i < 3; i++) {
+    let state = env.reset();
+    let res = env.step(3);
+    agent.learn(state, 3, res.reward, res.state, res.done);
+    state = res.state;
+    res = env.step(1);
+    agent.learn(state, 1, res.reward, res.state, res.done);
+  }
+  const keyStart = Array.from(new Float32Array([0, 0])).join(',');
+  const keyRight = Array.from(new Float32Array([1, 0])).join(',');
+  const qStart = agent.qTable.get(keyStart);
+  const qRight = agent.qTable.get(keyRight);
+  assert.ok(Math.abs(qStart[3] - expectedFirst) < 1e-6);
+  assert.ok(Math.abs(qRight[1] - expectedSecond) < 1e-6);
+}


### PR DESCRIPTION
## Context
- introduce Monte Carlo learning to the grid world demo

## Description
- implement first-visit Monte Carlo agent with optional exploring starts
- expose Monte Carlo agent in the UI agent selector
- validate Monte Carlo estimates against returns in the grid world

## Changes
- add `monteCarloAgent.js` implementing episodic value updates
- allow selecting the Monte Carlo agent in `index.html` and `createAgent`
- test that Monte Carlo values match empirical returns

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b30de1d5a48332ac0ac88ccb9cc573