### PR TITLE
Add Double Q-learning agent

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <label>Agent:
         <select id="agent-select">
           <option value="rl">Q-learning</option>
+          <option value="double">Double Q-learning</option>
           <option value="mc">Monte Carlo</option>
           <option value="qlambda">Q(&lambda;)</option>
           <option value="sarsa">SARSA</option>

--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -158,6 +158,7 @@ export class RLAgent {
       Array.from(this.countTable.entries()).map(([k, v]) => [k, Array.from(v)])
     );
     return {
+      type: 'rl',
       epsilon: this.epsilon,
       gamma: this.gamma,
       learningRate: this.learningRate,

--- a/src/rl/doubleQAgent.js
+++ b/src/rl/doubleQAgent.js
@@ -1,0 +1,118 @@
+import { RLAgent } from './agent.js';
+
+export class DoubleQAgent extends RLAgent {
+  constructor(options = {}) {
+    super(options);
+    this.qTableA = new Map();
+    this.qTableB = new Map();
+  }
+
+  _ensure(table, state) {
+    const key = this._key(state);
+    if (!table.has(key)) {
+      table.set(key, new Float32Array(4));
+    }
+    return table.get(key);
+  }
+
+  _ensureBoth(state) {
+    const qa = this._ensure(this.qTableA, state);
+    const qb = this._ensure(this.qTableB, state);
+    return [qa, qb];
+  }
+
+  act(state, update = true) {
+    const [qa, qb] = this._ensureBoth(state);
+    const qVals = qa.map((v, i) => (v + qb[i]) / 2);
+    switch (this.policy) {
+      case 'greedy':
+        return this._greedy(qVals);
+      case 'softmax':
+        return this._softmax(qVals);
+      case 'thompson':
+        return this._thompson(state, qVals, update);
+      case 'ucb':
+        return this._ucb(state, qVals, update);
+      case 'epsilon-greedy':
+      default:
+        return this._epsilonGreedy(qVals);
+    }
+  }
+
+  learn(state, action, reward, nextState, done) {
+    const updateA = Math.random() < 0.5;
+    const [qa, qb] = this._ensureBoth(state);
+    const [nextQa, nextQb] = this._ensureBoth(nextState);
+    if (updateA) {
+      let best = 0;
+      for (let i = 1; i < nextQa.length; i++) {
+        if (nextQa[i] > nextQa[best]) best = i;
+      }
+      const target = reward + (done ? 0 : this.gamma * nextQb[best]);
+      qa[action] += this.learningRate * (target - qa[action]);
+    } else {
+      let best = 0;
+      for (let i = 1; i < nextQb.length; i++) {
+        if (nextQb[i] > nextQb[best]) best = i;
+      }
+      const target = reward + (done ? 0 : this.gamma * nextQa[best]);
+      qb[action] += this.learningRate * (target - qb[action]);
+    }
+    this.decayEpsilon();
+  }
+
+  reset() {
+    super.reset();
+    this.qTableA.clear();
+    this.qTableB.clear();
+  }
+
+  toJSON() {
+    const tableA = Object.fromEntries(
+      Array.from(this.qTableA.entries()).map(([k, v]) => [k, Array.from(v)])
+    );
+    const tableB = Object.fromEntries(
+      Array.from(this.qTableB.entries()).map(([k, v]) => [k, Array.from(v)])
+    );
+    const counts = Object.fromEntries(
+      Array.from(this.countTable.entries()).map(([k, v]) => [k, Array.from(v)])
+    );
+    return {
+      type: 'double',
+      epsilon: this.epsilon,
+      gamma: this.gamma,
+      learningRate: this.learningRate,
+      epsilonDecay: this.epsilonDecay,
+      minEpsilon: this.minEpsilon,
+      policy: this.policy,
+      temperature: this.temperature,
+      ucbC: this.ucbC,
+      qTableA: tableA,
+      qTableB: tableB,
+      countTable: counts
+    };
+  }
+
+  static fromJSON(data) {
+    const agent = new DoubleQAgent({
+      epsilon: data.epsilon,
+      gamma: data.gamma,
+      learningRate: data.learningRate,
+      epsilonDecay: data.epsilonDecay,
+      minEpsilon: data.minEpsilon,
+      policy: data.policy,
+      temperature: data.temperature,
+      ucbC: data.ucbC
+    });
+    for (const [k, v] of Object.entries(data.qTableA || {})) {
+      agent.qTableA.set(k, new Float32Array(v));
+    }
+    for (const [k, v] of Object.entries(data.qTableB || {})) {
+      agent.qTableB.set(k, new Float32Array(v));
+    }
+    for (const [k, v] of Object.entries(data.countTable || {})) {
+      agent.countTable.set(k, new Uint32Array(v));
+    }
+    return agent;
+  }
+}

--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -1,5 +1,6 @@
 import { RLAgent } from './agent.js';
 import { RLTrainer } from './training.js';
+import { DoubleQAgent } from './doubleQAgent.js';
 
 export function saveAgent(agent, storage = globalThis.localStorage) {
   const data = JSON.stringify(agent.toJSON());
@@ -9,7 +10,13 @@ export function saveAgent(agent, storage = globalThis.localStorage) {
 export function loadAgent(trainer, storage = globalThis.localStorage) {
   const data = storage.getItem('agent');
   if (!data) return trainer.agent;
-  const agent = RLAgent.fromJSON(JSON.parse(data));
+  const parsed = JSON.parse(data);
+  let agent;
+  if (parsed.type === 'double') {
+    agent = DoubleQAgent.fromJSON(parsed);
+  } else {
+    agent = RLAgent.fromJSON(parsed);
+  }
   trainer.agent = agent;
   trainer.reset();
   return agent;

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -6,6 +6,7 @@ import { DynaQAgent } from '../rl/dynaQAgent.js';
 import { QLambdaAgent } from '../rl/qLambdaAgent.js';
 import { MonteCarloAgent } from '../rl/monteCarloAgent.js';
 import { ActorCriticAgent } from '../rl/actorCriticAgent.js';
+import { DoubleQAgent } from '../rl/doubleQAgent.js';
 import { RLTrainer } from '../rl/training.js';
 import { saveAgent, loadAgent } from '../rl/storage.js';
 import { LiveChart } from './liveChart.js';
@@ -31,6 +32,7 @@ function createAgent(type) {
   if (type === 'qlambda') return new QLambdaAgent(options);
   if (type === 'mc') return new MonteCarloAgent(options);
   if (type === 'ac') return new ActorCriticAgent(options);
+  if (type === 'double') return new DoubleQAgent(options);
   return new RLAgent(options);
 }
 

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -15,6 +15,9 @@ export async function run(assert) {
   assert.ok(html.includes('<option value="ac">Actor-Critic</option>'));
   assert.ok(js.includes("import { ActorCriticAgent } from '../rl/actorCriticAgent.js';"));
   assert.ok(js.includes("if (type === 'ac') return new ActorCriticAgent(options);"));
+  assert.ok(html.includes('<option value="double">Double Q-learning</option>'));
+  assert.ok(js.includes("import { DoubleQAgent } from '../rl/doubleQAgent.js';"));
+  assert.ok(js.includes("if (type === 'double') return new DoubleQAgent(options);"));
   assert.ok(!html.includes('<option value="dqn">'));
   assert.ok(!html.includes('@tensorflow/tfjs'));
   assert.ok(!js.includes('@tensorflow/tfjs'));

--- a/tests/test_double_q_agent.js
+++ b/tests/test_double_q_agent.js
@@ -1,0 +1,53 @@
+import { RLAgent } from '../src/rl/agent.js';
+import { DoubleQAgent } from '../src/rl/doubleQAgent.js';
+
+function createRng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 4294967296;
+    return s / 4294967296;
+  };
+}
+
+class RandomRewardEnv {
+  constructor(rng) {
+    this.rng = rng;
+    this.state = new Float32Array([0, 0]);
+  }
+  reset() {
+    return this.state;
+  }
+  step(action) {
+    return { state: this.state, reward: this.rng(), done: false };
+  }
+}
+
+async function train(agent, steps, seed) {
+  const rng = createRng(seed);
+  const env = new RandomRewardEnv(rng);
+  const orig = Math.random;
+  Math.random = rng;
+  let state = env.reset();
+  for (let i = 0; i < steps; i++) {
+    const action = agent.act(state);
+    const { state: next, reward, done } = env.step(action);
+    agent.learn(state, action, reward, next, done);
+    state = next;
+  }
+  Math.random = orig;
+  return agent;
+}
+
+export async function run(assert) {
+  const steps = 5000;
+  const qAgent = await train(new RLAgent({ epsilon: 1, epsilonDecay: 1, gamma: 0.9, learningRate: 0.1 }), steps, 42);
+  const dqAgent = await train(new DoubleQAgent({ epsilon: 1, epsilonDecay: 1, gamma: 0.9, learningRate: 0.1 }), steps, 42);
+  const key = '0,0';
+  const qVals = qAgent.qTable.get(key);
+  const qMax = Math.max(...qVals);
+  const qa = dqAgent.qTableA.get(key);
+  const qb = dqAgent.qTableB.get(key);
+  const avg = qa.map((v, i) => (v + qb[i]) / 2);
+  const dMax = Math.max(...avg);
+  assert.ok(qMax > dMax);
+}


### PR DESCRIPTION
## Context
- introduce Double Q-learning to reduce overestimation bias

## Description
- implement a DoubleQAgent with two Q tables and randomized updates
- wire agent into trainer UI and persistence layer
- test dropdown integration and overestimation reduction

## Changes
- add `DoubleQAgent` with dual tables, JSON serialization, and learning logic
- expose agent in UI dropdown and loader
- expand tests for UI integration and overestimation bias

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b3152982148332a5d4249e40caf3d8