### PR TITLE
Add prioritized experience replay and trainer integration

### DIFF
--- a/src/rl/experienceReplay.js
+++ b/src/rl/experienceReplay.js
@@ -1,0 +1,60 @@
+export class ExperienceReplay {
+  constructor(capacity = 1000, alpha = 0.6, beta = 0.4) {
+    this.capacity = capacity;
+    this.alpha = alpha;
+    this.beta = beta;
+    this.buffer = [];
+    this.priorities = [];
+    this.position = 0;
+  }
+
+  add(transition, priority = 1) {
+    if (this.buffer.length < this.capacity) {
+      this.buffer.push(transition);
+      this.priorities.push(priority);
+    } else {
+      this.buffer[this.position] = transition;
+      this.priorities[this.position] = priority;
+    }
+    this.position = (this.position + 1) % this.capacity;
+  }
+
+  sample(count, strategy = 'uniform') {
+    if (this.buffer.length === 0) return [];
+    const batch = [];
+    if (strategy === 'priority') {
+      const weights = this.priorities.slice(0, this.buffer.length).map(p => Math.pow(p, this.alpha));
+      const total = weights.reduce((a, b) => a + b, 0);
+      if (total === 0) {
+        for (let i = 0; i < count; i++) {
+          const idx = Math.floor(Math.random() * this.buffer.length);
+          batch.push({ index: idx, ...this.buffer[idx] });
+        }
+      } else {
+        for (let i = 0; i < count; i++) {
+          const r = Math.random() * total;
+          let acc = 0;
+          for (let j = 0; j < this.buffer.length; j++) {
+            acc += weights[j];
+            if (r <= acc) {
+              batch.push({ index: j, ...this.buffer[j] });
+              break;
+            }
+          }
+        }
+      }
+    } else {
+      for (let i = 0; i < count; i++) {
+        const idx = Math.floor(Math.random() * this.buffer.length);
+        batch.push({ index: idx, ...this.buffer[idx] });
+      }
+    }
+    return batch;
+  }
+
+  updatePriority(index, priority) {
+    if (index >= 0 && index < this.priorities.length) {
+      this.priorities[index] = priority;
+    }
+  }
+}

--- a/tests/test_experience_replay.js
+++ b/tests/test_experience_replay.js
@@ -1,0 +1,52 @@
+import { ExperienceReplay } from '../src/rl/experienceReplay.js';
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+import { RLTrainer } from '../src/rl/training.js';
+
+export async function run(testAssert) {
+  // Insertion and capacity
+  const buffer = new ExperienceReplay(2);
+  buffer.add({ state: 1, action: 0, reward: 0, nextState: 2, done: false }, 1);
+  buffer.add({ state: 2, action: 1, reward: 1, nextState: 3, done: false }, 2);
+  buffer.add({ state: 3, action: 2, reward: 2, nextState: 4, done: true }, 3);
+  testAssert.strictEqual(buffer.buffer.length, 2);
+  const states = buffer.buffer.map(t => t.state).sort();
+  testAssert.deepStrictEqual(states, [2, 3]);
+
+  // Sampling strategies
+  const stratBuffer = new ExperienceReplay(3);
+  stratBuffer.add({ state: 'a' }, 0);
+  stratBuffer.add({ state: 'b' }, 5);
+  stratBuffer.add({ state: 'c' }, 0);
+  const [sampled] = stratBuffer.sample(1, 'priority');
+  testAssert.strictEqual(sampled.state, 'b');
+
+  const uniformSamples = stratBuffer.sample(2, 'uniform');
+  testAssert.strictEqual(uniformSamples.length, 2);
+
+  // Integration with RLTrainer
+  class StubAgent {
+    constructor() {
+      this.epsilon = 0;
+      this.calls = [];
+    }
+    act() {
+      return 0;
+    }
+    async learn(...args) {
+      this.calls.push(args);
+    }
+  }
+  const env = new GridWorldEnvironment(2);
+  const agent = new StubAgent();
+  const replay = new ExperienceReplay(5);
+  const trainer = new RLTrainer(agent, env, {
+    replayBuffer: replay,
+    replaySamples: 1,
+    replayStrategy: 'uniform'
+  });
+  trainer.state = env.reset();
+  await trainer.step();
+  testAssert.strictEqual(replay.buffer.length, 1);
+  testAssert.strictEqual(agent.calls.length, 2);
+  testAssert.deepStrictEqual(agent.calls[0], agent.calls[1]);
+}


### PR DESCRIPTION
### Context
Adds a prioritized experience replay buffer and integrates it with RLTrainer.

### Description
- Introduces ExperienceReplay class to store transitions with optional priorities.
- Extends RLTrainer to use a replay buffer and sample transitions using uniform or priority strategies.
- Exposes buffer capacity, alpha and beta through trainer options.
- Adds tests for replay buffer behavior and trainer integration.

### Changes
- src/rl/experienceReplay.js
- src/rl/training.js
- tests/test_experience_replay.js

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b32368eed483328077323dde6fa8d6