### PR TITLE
refactor: centralize policy selection logic

### DIFF
--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -25,9 +25,11 @@ export class RLAgent {
     return this.qTable.get(key);
   }
 
-  /** Choose an action using the configured policy. */
-  act(state, update = true) {
-    const qVals = this._ensure(state);
+  /**
+   * Select an action using the configured policy.
+   * @protected
+   */
+  _selectAction(qVals, state, update = true) {
     switch (this.policy) {
       case 'greedy':
         return this._greedy(qVals);
@@ -41,6 +43,12 @@ export class RLAgent {
       default:
         return this._epsilonGreedy(qVals);
     }
+  }
+
+  /** Choose an action using the configured policy. */
+  act(state, update = true) {
+    const qVals = this._ensure(state);
+    return this._selectAction(qVals, state, update);
   }
 
   _random() {

--- a/src/rl/doubleQAgent.js
+++ b/src/rl/doubleQAgent.js
@@ -24,19 +24,7 @@ export class DoubleQAgent extends RLAgent {
   act(state, update = true) {
     const [qa, qb] = this._ensureBoth(state);
     const qVals = qa.map((v, i) => (v + qb[i]) / 2);
-    switch (this.policy) {
-      case 'greedy':
-        return this._greedy(qVals);
-      case 'softmax':
-        return this._softmax(qVals);
-      case 'thompson':
-        return this._thompson(state, qVals, update);
-      case 'ucb':
-        return this._ucb(state, qVals, update);
-      case 'epsilon-greedy':
-      default:
-        return this._epsilonGreedy(qVals);
-    }
+    return this._selectAction(qVals, state, update);
   }
 
   learn(state, action, reward, nextState, done) {

--- a/tests/test_double_q_agent.js
+++ b/tests/test_double_q_agent.js
@@ -39,6 +39,25 @@ async function train(agent, steps, seed) {
 }
 
 export async function run(assert) {
+  {
+    const agent = new DoubleQAgent();
+    const state = new Float32Array([0, 0]);
+    const key = Array.from(state).join(',');
+    agent.qTableA.set(key, new Float32Array([1, 2, 3, 4]));
+    agent.qTableB.set(key, new Float32Array([4, 3, 2, 1]));
+    let called = false;
+    agent._selectAction = (qVals, s, update) => {
+      called = true;
+      assert.deepStrictEqual(Array.from(qVals), [2.5, 2.5, 2.5, 2.5]);
+      assert.strictEqual(s, state);
+      assert.strictEqual(update, false);
+      return 3;
+    };
+    const action = agent.act(state, false);
+    assert.ok(called);
+    assert.strictEqual(action, 3);
+  }
+
   const steps = 5000;
   const qAgent = await train(new RLAgent({ epsilon: 1, epsilonDecay: 1, gamma: 0.9, learningRate: 0.1 }), steps, 42);
   const dqAgent = await train(new DoubleQAgent({ epsilon: 1, epsilonDecay: 1, gamma: 0.9, learningRate: 0.1 }), steps, 42);


### PR DESCRIPTION
## Context
- remove duplicated policy dispatch across agents

## Description
- introduce protected `_selectAction` helper
- delegate action selection in `RLAgent` and `DoubleQAgent`
- test helper delegation in DoubleQAgent

## Changes
- add `_selectAction` to `RLAgent`
- refactor `DoubleQAgent.act` to use helper
- extend tests for delegation

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b335353ca88332b7ab61bfccabe65e