### PR TITLE
feat: centralize RL serialization utilities

### DIFF
--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -1,3 +1,5 @@
+import { mapToObject, objectToMap } from './utils/serialization.js';
+
 export class RLAgent {
   constructor(options = {}) {
     this.initialEpsilon = options.epsilon ?? 0.1;
@@ -159,12 +161,6 @@ export class RLAgent {
 
   /** Serialize agent state to a plain object. */
   toJSON() {
-    const table = Object.fromEntries(
-      Array.from(this.qTable.entries()).map(([k, v]) => [k, Array.from(v)])
-    );
-    const counts = Object.fromEntries(
-      Array.from(this.countTable.entries()).map(([k, v]) => [k, Array.from(v)])
-    );
     return {
       type: 'rl',
       epsilon: this.epsilon,
@@ -175,8 +171,8 @@ export class RLAgent {
       policy: this.policy,
       temperature: this.temperature,
       ucbC: this.ucbC,
-      qTable: table,
-      countTable: counts
+      qTable: mapToObject(this.qTable),
+      countTable: mapToObject(this.countTable)
     };
   }
 
@@ -192,12 +188,8 @@ export class RLAgent {
       temperature: data.temperature,
       ucbC: data.ucbC
     });
-    for (const [k, v] of Object.entries(data.qTable || {})) {
-      agent.qTable.set(k, new Float32Array(v));
-    }
-    for (const [k, v] of Object.entries(data.countTable || {})) {
-      agent.countTable.set(k, new Uint32Array(v));
-    }
+    agent.qTable = objectToMap(data.qTable, Float32Array);
+    agent.countTable = objectToMap(data.countTable, Uint32Array);
     return agent;
   }
 }

--- a/src/rl/qLambdaAgent.js
+++ b/src/rl/qLambdaAgent.js
@@ -45,23 +45,20 @@ export class QLambdaAgent extends RLAgent {
   }
 
   static fromJSON(data) {
+    const base = RLAgent.fromJSON(data);
     const agent = new QLambdaAgent({
-      epsilon: data.epsilon,
-      gamma: data.gamma,
-      learningRate: data.learningRate,
-      epsilonDecay: data.epsilonDecay,
-      minEpsilon: data.minEpsilon,
-      policy: data.policy,
-      temperature: data.temperature,
-      ucbC: data.ucbC,
+      epsilon: base.epsilon,
+      gamma: base.gamma,
+      learningRate: base.learningRate,
+      epsilonDecay: base.epsilonDecay,
+      minEpsilon: base.minEpsilon,
+      policy: base.policy,
+      temperature: base.temperature,
+      ucbC: base.ucbC,
       lambda: data.lambda
     });
-    for (const [k, v] of Object.entries(data.qTable || {})) {
-      agent.qTable.set(k, new Float32Array(v));
-    }
-    for (const [k, v] of Object.entries(data.countTable || {})) {
-      agent.countTable.set(k, new Uint32Array(v));
-    }
+    agent.qTable = base.qTable;
+    agent.countTable = base.countTable;
     return agent;
   }
 }

--- a/src/rl/utils/serialization.js
+++ b/src/rl/utils/serialization.js
@@ -1,0 +1,13 @@
+export function mapToObject(map) {
+  return Object.fromEntries(
+    Array.from(map.entries()).map(([k, v]) => [k, Array.from(v)])
+  );
+}
+
+export function objectToMap(obj = {}, ArrayType = Float32Array) {
+  const map = new Map();
+  for (const [k, v] of Object.entries(obj)) {
+    map.set(k, new ArrayType(v));
+  }
+  return map;
+}

--- a/tests/test_double_q_agent.js
+++ b/tests/test_double_q_agent.js
@@ -69,4 +69,13 @@ export async function run(assert) {
   const avg = qa.map((v, i) => (v + qb[i]) / 2);
   const dMax = Math.max(...avg);
   assert.ok(qMax > dMax);
+
+  dqAgent.qTableA.set(key, new Float32Array([1, 2, 3, 4]));
+  dqAgent.qTableB.set(key, new Float32Array([4, 3, 2, 1]));
+  dqAgent.countTable.set(key, new Uint32Array([1, 2, 3, 4]));
+  const json = dqAgent.toJSON();
+  const restored = DoubleQAgent.fromJSON(json);
+  assert.deepStrictEqual(Array.from(restored.qTableA.get(key)), [1, 2, 3, 4]);
+  assert.deepStrictEqual(Array.from(restored.qTableB.get(key)), [4, 3, 2, 1]);
+  assert.deepStrictEqual(Array.from(restored.countTable.get(key)), [1, 2, 3, 4]);
 }

--- a/tests/test_q_lambda_agent.js
+++ b/tests/test_q_lambda_agent.js
@@ -15,4 +15,10 @@ export async function run(assert) {
   const rlVal = rl.qTable.get(key)[3];
   const qlVal = ql.qTable.get(key)[3];
   assert.ok(qlVal > rlVal);
+
+  ql.qTable.set(key, new Float32Array([1, 2, 3, 4]));
+  const json = ql.toJSON();
+  const restored = QLambdaAgent.fromJSON(json);
+  assert.strictEqual(restored.lambda, ql.lambda);
+  assert.deepStrictEqual(Array.from(restored.qTable.get(key)), [1, 2, 3, 4]);
 }

--- a/tests/test_rl_agent.js
+++ b/tests/test_rl_agent.js
@@ -1,7 +1,14 @@
 import { RLAgent } from '../src/rl/agent.js';
 import { saveAgent, loadAgent } from '../src/rl/storage.js';
+import { mapToObject, objectToMap } from '../src/rl/utils/serialization.js';
 
 export async function run(assert) {
+  const map = new Map([['a', new Float32Array([1, 2])]]);
+  const obj = mapToObject(map);
+  assert.deepStrictEqual(obj, { a: [1, 2] });
+  const restored = objectToMap(obj, Float32Array);
+  assert.deepStrictEqual(Array.from(restored.get('a')), [1, 2]);
+
   const agent = new RLAgent({
     epsilon: 1,
     epsilonDecay: 0.5,


### PR DESCRIPTION
## Context
- unify map serialization across agents

## Description
- introduce mapToObject and objectToMap helpers
- refactor RLAgent and variants to use shared serialization logic
- expand tests for serialization utilities and agents

## Changes
- add src/rl/utils/serialization.js
- refactor RLAgent, DoubleQAgent, QLambdaAgent serialization
- update unit tests for new utilities

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b33f27c5a08332b92a47ed62f63eaa