### PR TITLE
refactor: separate experience replay sampling strategies

### DIFF
--- a/src/rl/experienceReplay.js
+++ b/src/rl/experienceReplay.js
@@ -21,32 +21,42 @@ export class ExperienceReplay {
 
   sample(count, strategy = 'uniform') {
     if (this.buffer.length === 0) return [];
+    return strategy === 'priority'
+      ? this._samplePriority(count)
+      : this._sampleUniform(count);
+  }
+
+  _randomIndex() {
+    return Math.floor(Math.random() * this.buffer.length);
+  }
+
+  _sampleUniform(count) {
     const batch = [];
-    if (strategy === 'priority') {
-      const weights = this.priorities.slice(0, this.buffer.length).map(p => Math.pow(p, this.alpha));
-      const total = weights.reduce((a, b) => a + b, 0);
-      if (total === 0) {
-        for (let i = 0; i < count; i++) {
-          const idx = Math.floor(Math.random() * this.buffer.length);
-          batch.push({ index: idx, ...this.buffer[idx] });
+    for (let i = 0; i < count; i++) {
+      const idx = this._randomIndex();
+      batch.push({ index: idx, ...this.buffer[idx] });
+    }
+    return batch;
+  }
+
+  _samplePriority(count) {
+    const weights = this.priorities
+      .slice(0, this.buffer.length)
+      .map(p => Math.pow(p, this.alpha));
+    const total = weights.reduce((a, b) => a + b, 0);
+    if (total === 0) {
+      return this._sampleUniform(count);
+    }
+    const batch = [];
+    for (let i = 0; i < count; i++) {
+      const r = Math.random() * total;
+      let acc = 0;
+      for (let j = 0; j < this.buffer.length; j++) {
+        acc += weights[j];
+        if (r <= acc) {
+          batch.push({ index: j, ...this.buffer[j] });
+          break;
         }
-      } else {
-        for (let i = 0; i < count; i++) {
-          const r = Math.random() * total;
-          let acc = 0;
-          for (let j = 0; j < this.buffer.length; j++) {
-            acc += weights[j];
-            if (r <= acc) {
-              batch.push({ index: j, ...this.buffer[j] });
-              break;
-            }
-          }
-        }
-      }
-    } else {
-      for (let i = 0; i < count; i++) {
-        const idx = Math.floor(Math.random() * this.buffer.length);
-        batch.push({ index: idx, ...this.buffer[idx] });
       }
     }
     return batch;


### PR DESCRIPTION
## Context
- simplify experience replay sampling logic

## Description
- split priority and uniform sampling into private methods
- centralize random index selection

## Changes
- add `_samplePriority`, `_sampleUniform`, and `_randomIndex`
- `sample` delegates to appropriate strategy

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b3480dd7848332a861e9d406a4d910