### PR TITLE
Refactor UI into modular agent factory and renderer

### DIFF
--- a/src/ui/agentFactory.js
+++ b/src/ui/agentFactory.js
@@ -1,0 +1,33 @@
+import { RLAgent } from '../rl/agent.js';
+import { SarsaAgent } from '../rl/sarsaAgent.js';
+import { ExpectedSarsaAgent } from '../rl/expectedSarsaAgent.js';
+import { DynaQAgent } from '../rl/dynaQAgent.js';
+import { QLambdaAgent } from '../rl/qLambdaAgent.js';
+import { MonteCarloAgent } from '../rl/monteCarloAgent.js';
+import { ActorCriticAgent } from '../rl/actorCriticAgent.js';
+import { DoubleQAgent } from '../rl/doubleQAgent.js';
+
+const agentFactory = {
+  rl: RLAgent,
+  sarsa: SarsaAgent,
+  expected: ExpectedSarsaAgent,
+  dyna: DynaQAgent,
+  qlambda: QLambdaAgent,
+  mc: MonteCarloAgent,
+  ac: ActorCriticAgent,
+  double: DoubleQAgent
+};
+
+export function createAgent(type, options = {}) {
+  const defaults = {
+    epsilon: 1,
+    epsilonDecay: 0.995,
+    minEpsilon: 0.05,
+    policy: 'egreedy',
+    lambda: 0
+  };
+  const AgentClass = agentFactory[type] || RLAgent;
+  return new AgentClass({ ...defaults, ...options });
+}
+
+export { agentFactory };

--- a/src/ui/bindControls.js
+++ b/src/ui/bindControls.js
@@ -1,0 +1,98 @@
+import { createAgent } from './agentFactory.js';
+import { saveAgent, loadAgent } from '../rl/storage.js';
+
+export function bindControls(trainer, agent, render) {
+  let currentAgent = agent;
+
+  const agentSelect = document.getElementById('agent-select');
+  const policySelect = document.getElementById('policy-select');
+  const epsilonSlider = document.getElementById('epsilon-slider');
+  const epsilonValue = document.getElementById('epsilon-value');
+  const intervalSlider = document.getElementById('interval-slider');
+  const intervalValue = document.getElementById('interval-value');
+  const learningRateSlider = document.getElementById('learning-rate-slider');
+  const learningRateValue = document.getElementById('learning-rate-value');
+  const lambdaSlider = document.getElementById('lambda-slider');
+  const lambdaValue = document.getElementById('lambda-value');
+
+  function syncLearningRate() {
+    learningRateSlider.value = currentAgent.learningRate;
+    learningRateValue.textContent = currentAgent.learningRate.toFixed(2);
+  }
+
+  function syncLambda() {
+    lambdaSlider.value = currentAgent.lambda ?? parseFloat(lambdaSlider.value);
+    const val = parseFloat(lambdaSlider.value);
+    lambdaValue.textContent = val.toFixed(2);
+  }
+
+  epsilonSlider.value = currentAgent.epsilon;
+  epsilonValue.textContent = currentAgent.epsilon.toFixed(2);
+  policySelect.value = currentAgent.policy;
+  intervalSlider.value = trainer.intervalMs;
+  intervalValue.textContent = trainer.intervalMs;
+  syncLearningRate();
+  syncLambda();
+
+  agentSelect.addEventListener('change', e => {
+    currentAgent = createAgent(e.target.value, {
+      policy: policySelect.value,
+      lambda: parseFloat(lambdaSlider.value)
+    });
+    trainer.agent = currentAgent;
+    trainer.reset();
+    epsilonSlider.value = currentAgent.epsilon;
+    epsilonValue.textContent = currentAgent.epsilon.toFixed(2);
+    policySelect.value = currentAgent.policy;
+    syncLearningRate();
+    syncLambda();
+  });
+
+  policySelect.addEventListener('change', e => {
+    currentAgent.policy = e.target.value;
+  });
+
+  epsilonSlider.addEventListener('input', e => {
+    const val = parseFloat(e.target.value);
+    currentAgent.epsilon = val;
+    trainer.metrics.epsilon = val;
+    epsilonValue.textContent = val.toFixed(2);
+    document.getElementById('epsilon').textContent = val.toFixed(2);
+  });
+
+  intervalSlider.addEventListener('input', e => {
+    const val = parseInt(e.target.value, 10);
+    trainer.setIntervalMs(val);
+    intervalValue.textContent = val;
+  });
+
+  learningRateSlider.addEventListener('input', e => {
+    const val = parseFloat(e.target.value);
+    currentAgent.learningRate = val;
+    learningRateValue.textContent = val.toFixed(2);
+  });
+
+  lambdaSlider.addEventListener('input', e => {
+    const val = parseFloat(e.target.value);
+    currentAgent.lambda = val;
+    lambdaValue.textContent = val.toFixed(2);
+  });
+
+  document.getElementById('start').onclick = () => trainer.start();
+  document.getElementById('pause').onclick = () => trainer.pause();
+  document.getElementById('reset').onclick = () => {
+    trainer.reset();
+    epsilonSlider.value = currentAgent.epsilon;
+    epsilonValue.textContent = currentAgent.epsilon.toFixed(2);
+    syncLearningRate();
+  };
+  document.getElementById('save').onclick = () => saveAgent(currentAgent);
+  document.getElementById('load').onclick = () => {
+    currentAgent = loadAgent(trainer);
+    epsilonSlider.value = currentAgent.epsilon;
+    epsilonValue.textContent = currentAgent.epsilon.toFixed(2);
+    policySelect.value = currentAgent.policy;
+    syncLearningRate();
+    render(trainer.state);
+  };
+}

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,85 +1,24 @@
 import { GridWorldEnvironment } from '../rl/environment.js';
-import { RLAgent } from '../rl/agent.js';
-import { SarsaAgent } from '../rl/sarsaAgent.js';
-import { ExpectedSarsaAgent } from '../rl/expectedSarsaAgent.js';
-import { DynaQAgent } from '../rl/dynaQAgent.js';
-import { QLambdaAgent } from '../rl/qLambdaAgent.js';
-import { MonteCarloAgent } from '../rl/monteCarloAgent.js';
-import { ActorCriticAgent } from '../rl/actorCriticAgent.js';
-import { DoubleQAgent } from '../rl/doubleQAgent.js';
 import { RLTrainer } from '../rl/training.js';
-import { saveAgent, loadAgent } from '../rl/storage.js';
 import { LiveChart } from './liveChart.js';
+import { createAgent } from './agentFactory.js';
+import { initRenderer, render } from './renderGrid.js';
+import { bindControls } from './bindControls.js';
 
 const size = 5;
 const env = new GridWorldEnvironment(size);
+const gridEl = document.getElementById('grid');
+initRenderer(env, gridEl, size);
 
 const policySelect = document.getElementById('policy-select');
 const lambdaSlider = document.getElementById('lambda-slider');
-const lambdaValue = document.getElementById('lambda-value');
 
-function createAgent(type) {
-  const options = {
-    epsilon: 1,
-    epsilonDecay: 0.995,
-    minEpsilon: 0.05,
-    policy: policySelect.value,
-    lambda: parseFloat(lambdaSlider.value)
-  };
-  if (type === 'sarsa') return new SarsaAgent(options);
-  if (type === 'expected') return new ExpectedSarsaAgent(options);
-  if (type === 'dyna') return new DynaQAgent(options);
-  if (type === 'qlambda') return new QLambdaAgent(options);
-  if (type === 'mc') return new MonteCarloAgent(options);
-  if (type === 'ac') return new ActorCriticAgent(options);
-  if (type === 'double') return new DoubleQAgent(options);
-  return new RLAgent(options);
-}
+let agent = createAgent('rl', {
+  policy: policySelect.value,
+  lambda: parseFloat(lambdaSlider.value)
+});
 
-let agent = createAgent('rl');
-const gridEl = document.getElementById('grid');
-gridEl.style.setProperty('--size', size);
-
-const agentSelect = document.getElementById('agent-select');
 const liveChart = new LiveChart(document.getElementById('liveChart'));
-const epsilonSlider = document.getElementById('epsilon-slider');
-const epsilonValue = document.getElementById('epsilon-value');
-const intervalSlider = document.getElementById('interval-slider');
-const intervalValue = document.getElementById('interval-value');
-const learningRateSlider = document.getElementById('learning-rate-slider');
-const learningRateValue = document.getElementById('learning-rate-value');
-
-function syncLearningRate() {
-  learningRateSlider.value = agent.learningRate;
-  learningRateValue.textContent = agent.learningRate.toFixed(2);
-}
-
-function syncLambda() {
-  lambdaSlider.value = agent.lambda ?? parseFloat(lambdaSlider.value);
-  const val = parseFloat(lambdaSlider.value);
-  lambdaValue.textContent = val.toFixed(2);
-}
-
-function render(state) {
-  gridEl.innerHTML = '';
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      const cell = document.createElement('div');
-      cell.className = 'cell';
-      if (env.isObstacle(x, y)) cell.classList.add('obstacle');
-      if (x === state[0] && y === state[1]) cell.classList.add('agent');
-      if (x === size - 1 && y === size - 1) cell.classList.add('goal');
-      cell.addEventListener('click', () => {
-        if (x === env.agentPos.x && y === env.agentPos.y) return;
-        if (x === size - 1 && y === size - 1) return;
-        env.toggleObstacle(x, y);
-        render(env.getState());
-      });
-      gridEl.appendChild(cell);
-    }
-  }
-}
-
 const trainer = new RLTrainer(agent, env, {
   intervalMs: 100,
   liveChart,
@@ -90,76 +29,11 @@ const trainer = new RLTrainer(agent, env, {
     document.getElementById('reward').textContent = metrics.cumulativeReward.toFixed(2);
     document.getElementById('epsilon').textContent = metrics.epsilon.toFixed(2);
 
-    epsilonSlider.value = metrics.epsilon;
-    epsilonValue.textContent = metrics.epsilon.toFixed(2);
+    document.getElementById('epsilon-slider').value = metrics.epsilon;
+    document.getElementById('epsilon-value').textContent = metrics.epsilon.toFixed(2);
   }
 });
 
-epsilonSlider.value = agent.epsilon;
-epsilonValue.textContent = agent.epsilon.toFixed(2);
-policySelect.value = agent.policy;
-intervalSlider.value = trainer.intervalMs;
-intervalValue.textContent = trainer.intervalMs;
-syncLearningRate();
-syncLambda();
-
-agentSelect.addEventListener('change', e => {
-  agent = createAgent(e.target.value);
-  trainer.agent = agent;
-  trainer.reset();
-  epsilonSlider.value = agent.epsilon;
-  epsilonValue.textContent = agent.epsilon.toFixed(2);
-  policySelect.value = agent.policy;
-  syncLearningRate();
-  syncLambda();
-});
-
-policySelect.addEventListener('change', e => {
-  agent.policy = e.target.value;
-});
-
-epsilonSlider.addEventListener('input', e => {
-  const val = parseFloat(e.target.value);
-  agent.epsilon = val;
-  trainer.metrics.epsilon = val;
-  epsilonValue.textContent = val.toFixed(2);
-  document.getElementById('epsilon').textContent = val.toFixed(2);
-});
-
-intervalSlider.addEventListener('input', e => {
-  const val = parseInt(e.target.value, 10);
-  trainer.setIntervalMs(val);
-  intervalValue.textContent = val;
-});
-
-learningRateSlider.addEventListener('input', e => {
-  const val = parseFloat(e.target.value);
-  agent.learningRate = val;
-  learningRateValue.textContent = val.toFixed(2);
-});
-
-lambdaSlider.addEventListener('input', e => {
-  const val = parseFloat(e.target.value);
-  agent.lambda = val;
-  lambdaValue.textContent = val.toFixed(2);
-});
-
-document.getElementById('start').onclick = () => trainer.start();
-document.getElementById('pause').onclick = () => trainer.pause();
-document.getElementById('reset').onclick = () => {
-  trainer.reset();
-  epsilonSlider.value = agent.epsilon;
-  epsilonValue.textContent = agent.epsilon.toFixed(2);
-  syncLearningRate();
-};
-document.getElementById('save').onclick = () => saveAgent(agent);
-document.getElementById('load').onclick = () => {
-  agent = loadAgent(trainer);
-  epsilonSlider.value = agent.epsilon;
-  epsilonValue.textContent = agent.epsilon.toFixed(2);
-  policySelect.value = agent.policy;
-  syncLearningRate();
-  render(trainer.state);
-};
+bindControls(trainer, agent, render);
 
 render(env.reset());

--- a/src/ui/renderGrid.js
+++ b/src/ui/renderGrid.js
@@ -1,0 +1,30 @@
+let env;
+let gridEl;
+let size;
+
+export function initRenderer(environment, element, gridSize) {
+  env = environment;
+  gridEl = element;
+  size = gridSize;
+  gridEl.style.setProperty('--size', size);
+}
+
+export function render(state) {
+  gridEl.innerHTML = '';
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const cell = document.createElement('div');
+      cell.className = 'cell';
+      if (env.isObstacle(x, y)) cell.classList.add('obstacle');
+      if (x === state[0] && y === state[1]) cell.classList.add('agent');
+      if (x === size - 1 && y === size - 1) cell.classList.add('goal');
+      cell.addEventListener('click', () => {
+        if (x === env.agentPos.x && y === env.agentPos.y) return;
+        if (x === size - 1 && y === size - 1) return;
+        env.toggleObstacle(x, y);
+        render(env.getState());
+      });
+      gridEl.appendChild(cell);
+    }
+  }
+}

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -2,22 +2,22 @@ import fs from 'fs';
 
 export async function run(assert) {
   const html = fs.readFileSync('index.html', 'utf8');
-  const js = fs.readFileSync('src/ui/index.js', 'utf8');
+  const js = fs.readFileSync('src/ui/agentFactory.js', 'utf8');
   assert.ok(html.includes('<option value="mc">Monte Carlo</option>'));
   assert.ok(js.includes("import { MonteCarloAgent } from '../rl/monteCarloAgent.js';"));
-  assert.ok(js.includes("if (type === 'mc') return new MonteCarloAgent(options);"));
+  assert.ok(js.includes('mc: MonteCarloAgent'));
   assert.ok(html.includes('<option value="dyna">Dyna-Q</option>'));
   assert.ok(js.includes("import { DynaQAgent } from '../rl/dynaQAgent.js';"));
-  assert.ok(js.includes("if (type === 'dyna') return new DynaQAgent(options);"));
+  assert.ok(js.includes('dyna: DynaQAgent'));
   assert.ok(html.includes('<option value="qlambda">Q(&lambda;)</option>'));
   assert.ok(js.includes("import { QLambdaAgent } from '../rl/qLambdaAgent.js';"));
-  assert.ok(js.includes("if (type === 'qlambda') return new QLambdaAgent(options);"));
+  assert.ok(js.includes('qlambda: QLambdaAgent'));
   assert.ok(html.includes('<option value="ac">Actor-Critic</option>'));
   assert.ok(js.includes("import { ActorCriticAgent } from '../rl/actorCriticAgent.js';"));
-  assert.ok(js.includes("if (type === 'ac') return new ActorCriticAgent(options);"));
+  assert.ok(js.includes('ac: ActorCriticAgent'));
   assert.ok(html.includes('<option value="double">Double Q-learning</option>'));
   assert.ok(js.includes("import { DoubleQAgent } from '../rl/doubleQAgent.js';"));
-  assert.ok(js.includes("if (type === 'double') return new DoubleQAgent(options);"));
+  assert.ok(js.includes('double: DoubleQAgent'));
   assert.ok(!html.includes('<option value="dqn">'));
   assert.ok(!html.includes('@tensorflow/tfjs'));
   assert.ok(!js.includes('@tensorflow/tfjs'));

--- a/tests/test_learning_rate_control.js
+++ b/tests/test_learning_rate_control.js
@@ -2,10 +2,10 @@ import fs from 'fs';
 import { JSDOM } from 'jsdom';
 
 export async function run(assert) {
-  const js = fs.readFileSync('src/ui/index.js', 'utf8');
+  const js = fs.readFileSync('src/ui/bindControls.js', 'utf8');
   assert.ok(js.includes("const learningRateSlider = document.getElementById('learning-rate-slider');"));
   assert.ok(js.includes("learningRateSlider.addEventListener('input'"));
-  assert.ok(js.includes('agent.learningRate'));
+  assert.ok(js.includes('currentAgent.learningRate'));
   assert.ok(js.includes('learningRateValue.textContent = val.toFixed(2);'));
 
   const dom = new JSDOM(`<input id="learning-rate-slider"><span id="learning-rate-value"></span>`);


### PR DESCRIPTION
## Context
The previous UI script handled agent creation, grid rendering, and control bindings in one large module.

## Description
- Introduced `agentFactory` for mapping agent identifiers to classes and creating agents with defaults.
- Moved grid rendering logic to `renderGrid` and encapsulated control bindings in `bindControls`.
- Simplified the main UI entry point to wire together environment, agent, trainer and controls.
- Updated unit tests for the new module structure.

## Changes
- add `src/ui/agentFactory.js`
- add `src/ui/renderGrid.js`
- add `src/ui/bindControls.js`
- refactor `src/ui/index.js`
- update tests

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b34808b8488332a2296c13c5e80c82