### PR TITLE
Refactor policy selection, trainer metrics, and UI controls

### DIFF
--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -1,4 +1,5 @@
 import { mapToObject, objectToMap } from './utils/serialization.js';
+import { POLICIES, selectAction } from './policies.js';
 
 export class RLAgent {
   constructor(options = {}) {
@@ -8,7 +9,7 @@ export class RLAgent {
     this.learningRate = options.learningRate ?? 0.1;
     this.epsilonDecay = options.epsilonDecay ?? 0.99;
     this.minEpsilon = options.minEpsilon ?? 0.01;
-    this.policy = options.policy ?? 'epsilon-greedy';
+    this.policy = options.policy ?? POLICIES.EPSILON_GREEDY;
     this.temperature = options.temperature ?? 1;
     this.ucbC = options.ucbC ?? 2;
     this.qTable = new Map();
@@ -32,19 +33,7 @@ export class RLAgent {
    * @protected
    */
   _selectAction(qVals, state, update = true) {
-    switch (this.policy) {
-      case 'greedy':
-        return this.bestAction(qVals);
-      case 'softmax':
-        return this._softmax(qVals);
-      case 'thompson':
-        return this._thompson(state, qVals, update);
-      case 'ucb':
-        return this._ucb(state, qVals, update);
-      case 'epsilon-greedy':
-      default:
-        return this._epsilonGreedy(qVals);
-    }
+    return selectAction(this.policy, this, state, qVals, update);
   }
 
   /** Choose an action using the configured policy. */

--- a/src/rl/metricsTracker.js
+++ b/src/rl/metricsTracker.js
@@ -1,0 +1,35 @@
+export class MetricsTracker {
+  constructor(agent) {
+    this.reset(agent);
+  }
+
+  reset(agent) {
+    this.metrics = {
+      episode: 1,
+      steps: 0,
+      cumulativeReward: 0,
+      epsilon: agent.epsilon
+    };
+    this.episodeRewards = [];
+  }
+
+  update(reward, agent) {
+    this.metrics.steps += 1;
+    this.metrics.cumulativeReward += reward;
+    this.metrics.epsilon = agent.epsilon;
+    return { ...this.metrics };
+  }
+
+  endEpisode(agent) {
+    this.episodeRewards.push(this.metrics.cumulativeReward);
+    this.metrics.episode += 1;
+    this.metrics.steps = 0;
+    this.metrics.cumulativeReward = 0;
+    this.metrics.epsilon = agent.epsilon;
+    return { ...this.metrics };
+  }
+
+  get data() {
+    return this.metrics;
+  }
+}

--- a/src/rl/policies.js
+++ b/src/rl/policies.js
@@ -1,0 +1,23 @@
+export const POLICIES = {
+  EPSILON_GREEDY: 'epsilon-greedy',
+  GREEDY: 'greedy',
+  SOFTMAX: 'softmax',
+  THOMPSON: 'thompson',
+  UCB: 'ucb'
+};
+
+export function selectAction(policy, agent, state, qVals, update = true) {
+  switch (policy) {
+    case POLICIES.GREEDY:
+      return agent.bestAction(qVals);
+    case POLICIES.SOFTMAX:
+      return agent._softmax(qVals);
+    case POLICIES.THOMPSON:
+      return agent._thompson(state, qVals, update);
+    case POLICIES.UCB:
+      return agent._ucb(state, qVals, update);
+    case POLICIES.EPSILON_GREEDY:
+    default:
+      return agent._epsilonGreedy(qVals);
+  }
+}

--- a/src/ui/agentFactory.js
+++ b/src/ui/agentFactory.js
@@ -1,4 +1,5 @@
 import { RLAgent } from '../rl/agent.js';
+import { POLICIES } from '../rl/policies.js';
 import { SarsaAgent } from '../rl/sarsaAgent.js';
 import { ExpectedSarsaAgent } from '../rl/expectedSarsaAgent.js';
 import { DynaQAgent } from '../rl/dynaQAgent.js';
@@ -23,7 +24,7 @@ export function createAgent(type, options = {}) {
     epsilon: 1,
     epsilonDecay: 0.995,
     minEpsilon: 0.05,
-    policy: 'egreedy',
+    policy: POLICIES.EPSILON_GREEDY,
     lambda: 0
   };
   const AgentClass = agentFactory[type] || RLAgent;

--- a/tests/test_learning_rate_control.js
+++ b/tests/test_learning_rate_control.js
@@ -3,9 +3,9 @@ import { JSDOM } from 'jsdom';
 
 export async function run(assert) {
   const js = fs.readFileSync('src/ui/bindControls.js', 'utf8');
-  assert.ok(js.includes("const learningRateSlider = document.getElementById('learning-rate-slider');"));
+  assert.ok(js.includes("document.getElementById('learning-rate-slider')"));
   assert.ok(js.includes("learningRateSlider.addEventListener('input'"));
-  assert.ok(js.includes('currentAgent.learningRate'));
+  assert.ok(js.includes('agent.learningRate = val;'));
   assert.ok(js.includes('learningRateValue.textContent = val.toFixed(2);'));
 
   const dom = new JSDOM(`<input id="learning-rate-slider"><span id="learning-rate-value"></span>`);


### PR DESCRIPTION
## Context
- Standardize policy naming across modules
- Decompose UI control binding into smaller units
- Separate metrics tracking from RLTrainer

## Description
- Introduced shared policy constants and selector to unify agent policy handling
- Extracted metrics tracking into its own class and streamlined RLTrainer usage
- Rewrote control binding with focused helpers for initialization, sliders, and persistence

## Changes
- Added `policies.js` and wired default policy through agent factory and agents
- Added `MetricsTracker` and refactored `training.js`
- Split `bindControls` into modular functions and updated tests

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b34ad0cc208332ab3530ac9184fca6