### PR TITLE
feat: add optimistic agent and random policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 - **Tabular Q-Learning Agent:** Value estimates stored in a simple lookup table.
 - **SARSA and Expected SARSA Agents:** Alternatives to standard Q-learning.
 - **Dyna-Q Agent:** Combines Q-learning with planning from a learned model.
+- **Optimistic Q-Learning Agent:** Uses high initial values to encourage exploration.
 - **Epsilon-Greedy Exploration:** Exploration rate automatically decays during training.
+- **Random Policy:** Baseline policy that selects actions uniformly at random.
 - **Episode Trainer:** Run training loops with callbacks for visualization.
 - **Pure ES6 Modules:** No build step, works with static file hosting.
 - **Interactive Demo:** Open `index.html` to watch the agent learn in real time.

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
           <option value="expected">Expected SARSA</option>
           <option value="dyna">Dyna-Q</option>
           <option value="ac">Actor-Critic</option>
+          <option value="optimistic">Optimistic</option>
         </select>
       </label>
     </div>
@@ -37,6 +38,7 @@
           <option value="softmax">Softmax</option>
           <option value="ucb">UCB</option>
           <option value="thompson">Thompson Sampling</option>
+          <option value="random">Random</option>
         </select>
       </label>
     </div>

--- a/src/rl/optimisticAgent.js
+++ b/src/rl/optimisticAgent.js
@@ -1,0 +1,45 @@
+import { RLAgent } from './agent.js';
+
+/**
+ * RL agent with optimistic initial values to encourage exploration.
+ */
+export class OptimisticAgent extends RLAgent {
+  constructor(options = {}) {
+    super(options);
+    this.initialValue = options.initialValue ?? 1;
+  }
+
+  _ensure(state) {
+    const key = this._key(state);
+    if (!this.qTable.has(key)) {
+      const arr = new Float32Array(4);
+      arr.fill(this.initialValue);
+      this.qTable.set(key, arr);
+    }
+    return this.qTable.get(key);
+  }
+
+  toJSON() {
+    const data = super.toJSON();
+    data.initialValue = this.initialValue;
+    return data;
+  }
+
+  static fromJSON(data) {
+    const base = RLAgent.fromJSON(data);
+    const agent = new OptimisticAgent({
+      epsilon: base.epsilon,
+      gamma: base.gamma,
+      learningRate: base.learningRate,
+      epsilonDecay: base.epsilonDecay,
+      minEpsilon: base.minEpsilon,
+      policy: base.policy,
+      temperature: base.temperature,
+      ucbC: base.ucbC,
+      initialValue: data.initialValue
+    });
+    agent.qTable = base.qTable;
+    agent.countTable = base.countTable;
+    return agent;
+  }
+}

--- a/src/rl/policies.js
+++ b/src/rl/policies.js
@@ -3,7 +3,8 @@ export const POLICIES = {
   GREEDY: 'greedy',
   SOFTMAX: 'softmax',
   THOMPSON: 'thompson',
-  UCB: 'ucb'
+  UCB: 'ucb',
+  RANDOM: 'random'
 };
 
 export function selectAction(policy, agent, state, qVals, update = true) {
@@ -16,6 +17,8 @@ export function selectAction(policy, agent, state, qVals, update = true) {
       return agent._thompson(state, qVals, update);
     case POLICIES.UCB:
       return agent._ucb(state, qVals, update);
+    case POLICIES.RANDOM:
+      return agent._random();
     case POLICIES.EPSILON_GREEDY:
     default:
       return agent._epsilonGreedy(qVals);

--- a/src/ui/agentFactory.js
+++ b/src/ui/agentFactory.js
@@ -7,6 +7,7 @@ import { QLambdaAgent } from '../rl/qLambdaAgent.js';
 import { MonteCarloAgent } from '../rl/monteCarloAgent.js';
 import { ActorCriticAgent } from '../rl/actorCriticAgent.js';
 import { DoubleQAgent } from '../rl/doubleQAgent.js';
+import { OptimisticAgent } from '../rl/optimisticAgent.js';
 
 const agentFactory = {
   rl: RLAgent,
@@ -16,7 +17,8 @@ const agentFactory = {
   qlambda: QLambdaAgent,
   mc: MonteCarloAgent,
   ac: ActorCriticAgent,
-  double: DoubleQAgent
+  double: DoubleQAgent,
+  optimistic: OptimisticAgent
 };
 
 export function createAgent(type, options = {}) {

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -18,6 +18,9 @@ export async function run(assert) {
   assert.ok(html.includes('<option value="double">Double Q-learning</option>'));
   assert.ok(js.includes("import { DoubleQAgent } from '../rl/doubleQAgent.js';"));
   assert.ok(js.includes('double: DoubleQAgent'));
+  assert.ok(html.includes('<option value="optimistic">Optimistic</option>'));
+  assert.ok(js.includes("import { OptimisticAgent } from '../rl/optimisticAgent.js';"));
+  assert.ok(js.includes('optimistic: OptimisticAgent'));
   assert.ok(!html.includes('<option value="dqn">'));
   assert.ok(!html.includes('@tensorflow/tfjs'));
   assert.ok(!js.includes('@tensorflow/tfjs'));

--- a/tests/test_optimistic_agent.js
+++ b/tests/test_optimistic_agent.js
@@ -1,0 +1,12 @@
+import { OptimisticAgent } from '../src/rl/optimisticAgent.js';
+
+export async function run(assert) {
+  const state = new Float32Array([0, 0]);
+  const agent = new OptimisticAgent({ initialValue: 2 });
+  agent.act(state);
+  const key = Array.from(state).join(',');
+  const qVals = agent.qTable.get(key);
+  assert.deepStrictEqual(Array.from(qVals), [2, 2, 2, 2]);
+  agent.learn(state, 0, 1, state, true);
+  assert.ok(agent.qTable.get(key)[0] < 2);
+}

--- a/tests/test_policies.js
+++ b/tests/test_policies.js
@@ -11,9 +11,9 @@ export async function run(assert) {
   const softAgent = new RLAgent({ policy: 'softmax', temperature: 1 });
   softAgent.qTable.set(key, new Float32Array([1, 5, 1, 1]));
   const origRandom = Math.random;
-  Math.random = () => 0.5;
+  Math.random = () => { origRandom(); return 0.5; };
   assert.strictEqual(softAgent.act(state), 1);
-  Math.random = () => 0;
+  Math.random = () => { origRandom(); return 0; };
   assert.strictEqual(softAgent.act(state), 0);
   Math.random = origRandom;
 
@@ -31,4 +31,12 @@ export async function run(assert) {
   thompAgent._gaussian = () => 0;
   assert.strictEqual(thompAgent.act(state), 1);
   assert.strictEqual(thompAgent.countTable.get(key)[1], 1);
+
+  const randAgent = new RLAgent({ policy: 'random' });
+  const origRand = Math.random;
+  Math.random = () => { origRand(); return 0.95; };
+  assert.strictEqual(randAgent.act(state), 3);
+  Math.random = () => { origRand(); return 0.1; };
+  assert.strictEqual(randAgent.act(state), 0);
+  Math.random = origRand;
 }


### PR DESCRIPTION
## Context
- add new tabular agent and policy

## Description
- introduce OptimisticAgent with high initial Q-values
- add random policy option and integrate into UI

## Changes
- new OptimisticAgent with optimistic initialization
- random policy constant and selection logic
- UI updates and tests for new agent and policy

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b34ff6c6bc8332902fbc94d851b309