### PR TITLE
feat: add environment persistence and grid size control

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - **Episode Trainer:** Run training loops with callbacks for visualization.
 - **Pure ES6 Modules:** No build step, works with static file hosting.
 - **Interactive Demo:** Open `index.html` to watch the agent learn in real time.
+- **Adjustable Grid Size:** Change the environment dimensions directly from the UI.
+- **Environment Persistence:** Save and load grid size and obstacles.
 
 ## Project Structure
 
@@ -64,3 +66,4 @@ const restored = RLAgent.fromJSON(saved);
 ## Frontend Demo
 
 Open `index.html` in a browser to interact with the grid world. Use the Start, Pause and Reset buttons to control training and watch the agent improve.
+Use the Grid Size input to resize the environment and toggle cells to set obstacles. The Save and Load buttons persist both the agent and the environment layout in your browser.

--- a/index.html
+++ b/index.html
@@ -55,6 +55,9 @@
     <label>Interval (ms): <input type="range" id="interval-slider" min="10" max="1000" step="10" value="100"><span id="interval-value">100</span></label>
   </div>
   <div>
+    <label>Grid Size: <input type="number" id="grid-size" min="2" max="20" value="5"></label>
+  </div>
+  <div>
     <button id="start">Start</button>
     <button id="pause">Pause</button>
     <button id="reset">Reset</button>

--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -24,3 +24,14 @@ export function loadAgent(trainer, storage = globalThis.localStorage) {
   trainer.reset();
   return agent;
 }
+
+export function saveEnvironment(env, storage = globalThis.localStorage) {
+  const data = JSON.stringify({ size: env.size, obstacles: env.obstacles });
+  storage.setItem('environment', data);
+}
+
+export function loadEnvironment(storage = globalThis.localStorage) {
+  const data = storage.getItem('environment');
+  if (!data) return null;
+  return JSON.parse(data);
+}

--- a/src/ui/bindControls.js
+++ b/src/ui/bindControls.js
@@ -1,5 +1,5 @@
 import { createAgent } from './agentFactory.js';
-import { saveAgent, loadAgent } from '../rl/storage.js';
+import { saveAgent, loadAgent, saveEnvironment, loadEnvironment } from '../rl/storage.js';
 
 function getElements() {
   return {
@@ -87,23 +87,30 @@ function bindSliders(trainer, els, getAgent) {
   });
 }
 
-function bindPersistence(trainer, els, getAgent, setAgent, render) {
+function bindPersistence(trainer, els, getAgent, setAgent, render, getEnv, setEnv) {
   document.getElementById('start').onclick = () => trainer.start();
   document.getElementById('pause').onclick = () => trainer.pause();
   document.getElementById('reset').onclick = () => {
     trainer.reset();
     initializeControls(trainer, getAgent(), els);
   };
-  document.getElementById('save').onclick = () => saveAgent(getAgent());
+  document.getElementById('save').onclick = () => {
+    saveAgent(getAgent());
+    saveEnvironment(getEnv());
+  };
   document.getElementById('load').onclick = () => {
     const loaded = loadAgent(trainer);
     setAgent(loaded);
     initializeControls(trainer, loaded, els);
+    const envData = loadEnvironment();
+    if (envData) {
+      setEnv(envData.size, envData.obstacles);
+    }
     render(trainer.state);
   };
 }
 
-export function bindControls(trainer, agent, render) {
+export function bindControls(trainer, agent, render, getEnv, setEnv) {
   let currentAgent = agent;
   const getAgent = () => currentAgent;
   const setAgent = a => { currentAgent = a; };
@@ -113,5 +120,5 @@ export function bindControls(trainer, agent, render) {
   bindAgentSelection(trainer, els, getAgent, setAgent);
   bindPolicySelection(els, getAgent);
   bindSliders(trainer, els, getAgent);
-  bindPersistence(trainer, els, getAgent, setAgent, render);
+  bindPersistence(trainer, els, getAgent, setAgent, render, getEnv, setEnv);
 }

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -4,11 +4,12 @@ import { LiveChart } from './liveChart.js';
 import { createAgent } from './agentFactory.js';
 import { initRenderer, render } from './renderGrid.js';
 import { bindControls } from './bindControls.js';
+import { saveEnvironment } from '../rl/storage.js';
 
-const size = 5;
-const env = new GridWorldEnvironment(size);
 const gridEl = document.getElementById('grid');
-initRenderer(env, gridEl, size);
+const gridSizeInput = document.getElementById('grid-size');
+let env = new GridWorldEnvironment(parseInt(gridSizeInput.value, 10));
+initRenderer(env, gridEl, env.size);
 
 const policySelect = document.getElementById('policy-select');
 const lambdaSlider = document.getElementById('lambda-slider');
@@ -34,6 +35,20 @@ const trainer = new RLTrainer(agent, env, {
   }
 });
 
-bindControls(trainer, agent, render);
+function rebuildEnvironment(size, obstacles = []) {
+  env = new GridWorldEnvironment(size, obstacles);
+  trainer.env = env;
+  initRenderer(env, gridEl, size);
+  trainer.reset();
+  gridSizeInput.value = size;
+  saveEnvironment(env);
+}
+
+gridSizeInput.addEventListener('change', e => {
+  const newSize = parseInt(e.target.value, 10);
+  rebuildEnvironment(newSize);
+});
+
+bindControls(trainer, agent, render, () => env, rebuildEnvironment);
 
 render(env.reset());

--- a/src/ui/renderGrid.js
+++ b/src/ui/renderGrid.js
@@ -1,3 +1,5 @@
+import { saveEnvironment } from '../rl/storage.js';
+
 let env;
 let gridEl;
 let size;
@@ -22,6 +24,7 @@ export function render(state) {
         if (x === env.agentPos.x && y === env.agentPos.y) return;
         if (x === size - 1 && y === size - 1) return;
         env.toggleObstacle(x, y);
+        saveEnvironment(env);
         render(env.getState());
       });
       gridEl.appendChild(cell);

--- a/tests/test_environment_storage.js
+++ b/tests/test_environment_storage.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+import { saveEnvironment, loadEnvironment } from '../src/rl/storage.js';
+
+export async function run(assert) {
+  const html = fs.readFileSync('index.html', 'utf8');
+  assert.ok(html.includes('id="grid-size"'));
+
+  const js = fs.readFileSync('src/ui/renderGrid.js', 'utf8');
+  assert.ok(js.includes('saveEnvironment(env);'));
+
+  const storage = {
+    data: {},
+    setItem(k, v) { this.data[k] = v; },
+    getItem(k) { return this.data[k] ?? null; }
+  };
+
+  const env = new GridWorldEnvironment(4, [{ x: 1, y: 1 }]);
+  saveEnvironment(env, storage);
+  const loaded = loadEnvironment(storage);
+  assert.deepStrictEqual(loaded, { size: 4, obstacles: [{ x: 1, y: 1 }] });
+}


### PR DESCRIPTION
## Context
- expose grid size configuration
- persist environment layout with agent state

## Description
- add grid size input and rebuild environment when changed
- save and load environment size and obstacles through local storage
- update renderer to store obstacle toggles automatically

## Changes
- index.html
- src/ui/index.js
- src/rl/storage.js
- src/ui/bindControls.js
- src/ui/renderGrid.js
- README.md
- tests/test_environment_storage.js

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68b3aade08cc8332be978375135c210b