### PR TITLE
Add epsilon-greedy behavior to actor-critic agent

### DIFF
--- a/src/rl/actorCriticAgent.js
+++ b/src/rl/actorCriticAgent.js
@@ -45,7 +45,12 @@ export class ActorCriticAgent {
   }
 
   act(state) {
-    const probs = this.policyProbs(state);
+    const prefs = this._ensurePolicy(state);
+    const actionCount = prefs.length;
+    if (this.epsilon > 0 && Math.random() < this.epsilon) {
+      return Math.floor(Math.random() * actionCount);
+    }
+    const probs = this._softmax(Array.from(prefs));
     let r = Math.random();
     for (let i = 0; i < probs.length; i++) {
       r -= probs[i];
@@ -67,6 +72,7 @@ export class ActorCriticAgent {
       const grad = (i === action ? 1 - probs[i] : -probs[i]);
       prefs[i] += this.alphaActor * tdError * grad;
     }
+    this.decayEpsilon();
   }
 
   decayEpsilon() {


### PR DESCRIPTION
## Context
- ActorCriticAgent should balance exploration and exploitation.
- Existing implementation ignored epsilon configuration and never decayed it.

## Description
- Implement epsilon-greedy action selection and decay to respect exploration settings.
- Cover new behavior with targeted unit tests.

## Changes
- Sample random actions with probability `epsilon` and otherwise follow the softmax policy.
- Decay epsilon after every learning step and ensure reset restores the initial value.
- Add tests that pin action selection when epsilon triggers exploration, verify softmax usage, and confirm epsilon decay + reset behavior.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c87d489d20833287a145c84d88ebf1