### PR TITLE
Preserve trainer state when loading saved agents

### DIFF
--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -21,7 +21,11 @@ export function loadAgent(trainer, storage = globalThis.localStorage) {
     agent = RLAgent.fromJSON(parsed);
   }
   trainer.agent = agent;
-  trainer.reset();
+  if (typeof trainer.resetTrainerState === 'function') {
+    trainer.resetTrainerState();
+  } else {
+    trainer.reset();
+  }
   return agent;
 }
 

--- a/src/rl/training.js
+++ b/src/rl/training.js
@@ -33,6 +33,16 @@ export class RLTrainer {
     this.episodeRewards = this.metricsTracker.episodeRewards;
   }
 
+  _initializeTrainerState() {
+    this.state = this.env.reset();
+    this.metricsTracker.reset(this.agent);
+    this.metrics = this.metricsTracker.data;
+    this.episodeRewards = this.metricsTracker.episodeRewards;
+    if (this.onStep) {
+      this.onStep(this.state, 0, false, { ...this.metrics });
+    }
+  }
+
   async _applyTransition() {
     const action = await this.agent.act(this.state);
     const { state: nextState, reward, done } = this.env.step(action);
@@ -116,13 +126,12 @@ export class RLTrainer {
     if (typeof this.agent.reset === 'function') {
       this.agent.reset();
     }
-    this.state = this.env.reset();
-    this.metricsTracker.reset(this.agent);
-    this.metrics = this.metricsTracker.data;
-    this.episodeRewards = this.metricsTracker.episodeRewards;
-    if (this.onStep) {
-      this.onStep(this.state, 0, false, { ...this.metrics });
-    }
+    this._initializeTrainerState();
+  }
+
+  resetTrainerState() {
+    this.pause();
+    this._initializeTrainerState();
   }
 
   static async trainEpisodes(agent, env, episodes = 10, maxSteps = 50) {

--- a/tests/test_optimistic_agent.js
+++ b/tests/test_optimistic_agent.js
@@ -22,12 +22,15 @@ export async function run(assert) {
   const trainer = {
     agent: persistent,
     resetCalled: false,
-    reset() { this.resetCalled = true; }
+    resetTrainerStateCalled: false,
+    reset() { this.resetCalled = true; },
+    resetTrainerState() { this.resetTrainerStateCalled = true; }
   };
   saveAgent(persistent, storage);
   trainer.agent = null;
   loadAgent(trainer, storage);
-  assert.ok(trainer.resetCalled);
+  assert.ok(trainer.resetTrainerStateCalled);
+  assert.strictEqual(trainer.resetCalled, false);
   assert.ok(trainer.agent instanceof OptimisticAgent);
   const restored = trainer.agent.qTable.get(key);
   assert.deepStrictEqual(Array.from(restored), [2, 2, 2, 2]);

--- a/tests/test_rl_agent.js
+++ b/tests/test_rl_agent.js
@@ -42,12 +42,17 @@ export async function run(assert) {
   const trainer = {
     agent: greedyAgent,
     resetCalled: false,
-    reset() { this.resetCalled = true; }
+    resetTrainerStateCalled: false,
+    reset() { this.resetCalled = true; },
+    resetTrainerState() { this.resetTrainerStateCalled = true; }
   };
   saveAgent(greedyAgent, storage);
   trainer.agent = new RLAgent();
   loadAgent(trainer, storage);
-  assert.ok(trainer.resetCalled);
+  assert.ok(trainer.resetTrainerStateCalled);
+  assert.strictEqual(trainer.resetCalled, false);
   const restoredAction = trainer.agent.act(state);
   assert.strictEqual(restoredAction, action);
+  const restoredTable = trainer.agent.qTable.get(key);
+  assert.deepStrictEqual(Array.from(restoredTable), Array.from(greedyAgent.qTable.get(key)));
 }


### PR DESCRIPTION
## Context
Loading a saved agent should not wipe out its learned parameters when attaching it to an existing trainer instance.

## Description
Introduced a dedicated trainer helper that refreshes trainer state without clearing the agent, and updated storage utilities to rely on it so that persisted Q-tables remain intact after loading.

## Changes
- Added an internal initializer and a new `resetTrainerState` method on `RLTrainer` to refresh environment and metrics without touching the agent.
- Switched `loadAgent` to call the new helper (with a fallback) when attaching loaded agents.
- Extended agent persistence tests to cover the new helper usage and to assert that Q-tables survive save/load cycles.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c87d41fde88332bb6f362555f737a5