### PR TITLE
Guard learning rate controls for unsupported agents

### DIFF
--- a/src/ui/bindControls.js
+++ b/src/ui/bindControls.js
@@ -16,9 +16,26 @@ function getElements() {
   };
 }
 
+function hasLearningRate(agent) {
+  return agent && agent.learningRate !== undefined;
+}
+
 function syncLearningRate(agent, els) {
+  if (!hasLearningRate(agent)) {
+    return;
+  }
   els.learningRateSlider.value = agent.learningRate;
   els.learningRateValue.textContent = agent.learningRate.toFixed(2);
+}
+
+function updateLearningRateControl(agent, els) {
+  if (hasLearningRate(agent)) {
+    els.learningRateSlider.disabled = false;
+    syncLearningRate(agent, els);
+  } else {
+    els.learningRateSlider.disabled = true;
+    els.learningRateValue.textContent = 'N/A';
+  }
 }
 
 function syncLambda(agent, els) {
@@ -33,7 +50,7 @@ function initializeControls(trainer, agent, els) {
   els.policySelect.value = agent.policy;
   els.intervalSlider.value = trainer.intervalMs;
   els.intervalValue.textContent = trainer.intervalMs;
-  syncLearningRate(agent, els);
+  updateLearningRateControl(agent, els);
   syncLambda(agent, els);
 }
 
@@ -73,8 +90,11 @@ function bindSliders(trainer, els, getAgent) {
   });
 
   els.learningRateSlider.addEventListener('input', e => {
-    const val = parseFloat(e.target.value);
     const agent = getAgent();
+    if (agent.learningRate === undefined) {
+      return;
+    }
+    const val = parseFloat(e.target.value);
     agent.learningRate = val;
     els.learningRateValue.textContent = val.toFixed(2);
   });

--- a/tests/test_actor_critic_controls.js
+++ b/tests/test_actor_critic_controls.js
@@ -1,0 +1,102 @@
+import { JSDOM } from 'jsdom';
+
+export async function run(assert) {
+  const dom = new JSDOM(`<!doctype html><html><body>
+    <select id="agent-select">
+      <option value="rl">Q-learning</option>
+      <option value="ac">Actor-Critic</option>
+    </select>
+    <select id="policy-select">
+      <option value="epsilon-greedy">Epsilon-Greedy</option>
+      <option value="greedy">Greedy</option>
+    </select>
+    <input id="epsilon-slider" type="range" value="1" />
+    <span id="epsilon-value">1.00</span>
+    <span id="epsilon">1.00</span>
+    <input id="interval-slider" type="range" value="100" />
+    <span id="interval-value">100</span>
+    <input id="learning-rate-slider" type="range" value="0.1" />
+    <span id="learning-rate-value">0.10</span>
+    <input id="lambda-slider" type="range" value="0.9" />
+    <span id="lambda-value">0.90</span>
+    <button id="start"></button>
+    <button id="pause"></button>
+    <button id="reset"></button>
+    <button id="save"></button>
+    <button id="load"></button>
+  </body></html>`, { url: 'http://localhost' });
+
+  const { window } = dom;
+  const previousWindow = global.window;
+  const previousDocument = global.document;
+  const previousHTMLElement = global.HTMLElement;
+  const previousEvent = global.Event;
+
+  global.window = window;
+  global.document = window.document;
+  global.HTMLElement = window.HTMLElement;
+  global.Event = window.Event;
+
+  try {
+    const { bindControls } = await import('../src/ui/bindControls.js');
+
+    const initialAgent = {
+      epsilon: 0.5,
+      policy: 'epsilon-greedy',
+      learningRate: 0.1,
+      lambda: 0.8
+    };
+
+    const trainer = {
+      intervalMs: 100,
+      metrics: { epsilon: initialAgent.epsilon },
+      agent: initialAgent,
+      state: {},
+      setIntervalMs(ms) {
+        this.intervalMs = ms;
+      },
+      start() {},
+      pause() {},
+      reset() {
+        if (this.agent && typeof this.agent.reset === 'function') {
+          this.agent.reset();
+        }
+      }
+    };
+
+    const render = () => {};
+    const getEnv = () => ({ size: 5, obstacles: [] });
+    const setEnv = () => {};
+
+    bindControls(trainer, initialAgent, render, getEnv, setEnv);
+
+    const agentSelect = window.document.getElementById('agent-select');
+    const learningRateSlider = window.document.getElementById('learning-rate-slider');
+    const learningRateValue = window.document.getElementById('learning-rate-value');
+
+    agentSelect.value = 'ac';
+    agentSelect.dispatchEvent(new window.Event('change'));
+
+    assert.strictEqual(learningRateSlider.disabled, true);
+    assert.strictEqual(learningRateValue.textContent, 'N/A');
+
+    assert.doesNotThrow(() => {
+      learningRateSlider.value = '0.3';
+      learningRateSlider.dispatchEvent(new window.Event('input', { bubbles: true }));
+    });
+
+    agentSelect.value = 'rl';
+    agentSelect.dispatchEvent(new window.Event('change'));
+
+    assert.strictEqual(learningRateSlider.disabled, false);
+    assert.strictEqual(
+      learningRateValue.textContent,
+      parseFloat(learningRateSlider.value).toFixed(2)
+    );
+  } finally {
+    global.window = previousWindow;
+    global.document = previousDocument;
+    global.HTMLElement = previousHTMLElement;
+    global.Event = previousEvent;
+  }
+}

--- a/tests/test_learning_rate_control.js
+++ b/tests/test_learning_rate_control.js
@@ -7,6 +7,9 @@ export async function run(assert) {
   assert.ok(js.includes("learningRateSlider.addEventListener('input'"));
   assert.ok(js.includes('agent.learningRate = val;'));
   assert.ok(js.includes('learningRateValue.textContent = val.toFixed(2);'));
+  assert.ok(js.includes('if (agent.learningRate === undefined) {'));
+  assert.ok(js.includes("learningRateSlider.disabled = true;"));
+  assert.ok(js.includes("learningRateValue.textContent = 'N/A';"));
 
   const dom = new JSDOM(`<input id="learning-rate-slider"><span id="learning-rate-value"></span>`);
   const { document, Event } = dom.window;


### PR DESCRIPTION
## Context
- Switching to agents such as `ActorCriticAgent` in the UI caused the learning-rate controls to read `undefined`, producing runtime errors.

## Description
- Guarded synchronization of the learning-rate control so it only runs when the active agent exposes a `learningRate` property and disabled the slider/display otherwise.
- Stopped the slider handler from running when the agent lacks the property to avoid dereferencing `undefined`.
- Added coverage ensuring the UI can swap to `ActorCriticAgent` without emitting errors when users interact with the controls.

## Changes
- Update `src/ui/bindControls.js` to detect learning-rate support, disable the control when absent, and guard the slider listener.
- Extend `tests/test_learning_rate_control.js` to assert the new guard/disabled behavior is present.
- Add `tests/test_actor_critic_controls.js` to exercise switching to `ActorCriticAgent` and confirm the control state stays safe.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c87d4a8ba483328b7849f1faab9327