### PR TITLE
feat: visualize q-values in grid

### DIFF
--- a/src/ui/bindControls.js
+++ b/src/ui/bindControls.js
@@ -126,7 +126,7 @@ function bindPersistence(trainer, els, getAgent, setAgent, render, getEnv, setEn
     if (envData) {
       setEnv(envData.size, envData.obstacles);
     }
-    render(trainer.state);
+    render(trainer.state, getAgent());
   };
 }
 

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -24,7 +24,7 @@ const trainer = new RLTrainer(agent, env, {
   intervalMs: 100,
   liveChart,
   onStep: (state, reward, done, metrics) => {
-    render(state);
+    render(state, trainer.agent);
     document.getElementById('episode').textContent = metrics.episode;
     document.getElementById('steps').textContent = metrics.steps;
     document.getElementById('reward').textContent = metrics.cumulativeReward.toFixed(2);
@@ -51,4 +51,4 @@ gridSizeInput.addEventListener('change', e => {
 
 bindControls(trainer, agent, render, () => env, rebuildEnvironment);
 
-render(env.reset());
+render(env.reset(), agent);

--- a/src/ui/renderGrid.js
+++ b/src/ui/renderGrid.js
@@ -1,17 +1,150 @@
 import { saveEnvironment } from '../rl/storage.js';
 
+const ACTIONS = [
+  { key: 'up', symbol: '↑' },
+  { key: 'down', symbol: '↓' },
+  { key: 'left', symbol: '←' },
+  { key: 'right', symbol: '→' }
+];
+
+const ZERO_Q = new Float32Array(4);
+
 let env;
 let gridEl;
 let size;
+let currentAgent = null;
+
+function keyWithinGrid(key, gridSize) {
+  if (!key) return false;
+  const [xStr, yStr] = key.split(',');
+  const x = parseInt(xStr, 10);
+  const y = parseInt(yStr, 10);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return false;
+  if (gridSize === undefined) return true;
+  return x >= 0 && y >= 0 && x < gridSize && y < gridSize;
+}
+
+function getAgentTables(agent) {
+  if (!agent) return [];
+  const tables = [];
+  if (agent.qTable && typeof agent.qTable.get === 'function' && agent.qTable.size > 0) {
+    tables.push(agent.qTable);
+    return tables;
+  }
+  if (agent.qTableA && typeof agent.qTableA.get === 'function') tables.push(agent.qTableA);
+  if (agent.qTableB && typeof agent.qTableB.get === 'function') tables.push(agent.qTableB);
+  if (tables.length === 0 && agent.qTable && typeof agent.qTable.get === 'function') {
+    tables.push(agent.qTable);
+  }
+  return tables;
+}
+
+function summarizeQValues(agent, gridSize) {
+  const tables = getAgentTables(agent);
+  if (tables.length === 0) {
+    return { range: 0, min: 0, max: 0 };
+  }
+  let min = Infinity;
+  let max = -Infinity;
+  for (const table of tables) {
+    for (const [key, values] of table.entries()) {
+      if (!keyWithinGrid(key, gridSize)) continue;
+      for (const value of values) {
+        if (value < min) min = value;
+        if (value > max) max = value;
+      }
+    }
+  }
+  if (min === Infinity) {
+    return { range: 0, min: 0, max: 0 };
+  }
+  const range = Math.max(Math.abs(min), Math.abs(max));
+  return { range, min, max };
+}
+
+function getCellQValues(agent, x, y) {
+  const tables = getAgentTables(agent);
+  const key = `${x},${y}`;
+  if (tables.length === 0) return ZERO_Q;
+  if (tables.length === 1) {
+    return tables[0].get(key) ?? ZERO_Q;
+  }
+  let combined = null;
+  let count = 0;
+  for (const table of tables) {
+    const values = table.get(key);
+    if (!values) continue;
+    if (!combined) {
+      combined = new Float32Array(values);
+    } else {
+      for (let i = 0; i < values.length; i++) {
+        combined[i] += values[i];
+      }
+    }
+    count++;
+  }
+  if (!combined) {
+    return ZERO_Q;
+  }
+  if (count > 1) {
+    for (let i = 0; i < combined.length; i++) {
+      combined[i] /= count;
+    }
+  }
+  return combined;
+}
+
+function colorForValue(value, range) {
+  if (!Number.isFinite(value) || !Number.isFinite(range) || range <= 0) {
+    return 'rgba(255, 255, 255, 0.08)';
+  }
+  const normalized = Math.max(-1, Math.min(1, value / range));
+  const intensity = Math.abs(normalized);
+  const hue = normalized >= 0 ? 140 : 0;
+  const saturation = Math.round(30 + intensity * 60);
+  const lightness = Math.round(30 + (1 - intensity) * 20);
+  const alpha = Math.min(0.3 + intensity * 0.5, 0.8);
+  return `hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha.toFixed(2)})`;
+}
+
+function createQOverlay(qVals, range) {
+  const layer = document.createElement('div');
+  layer.className = 'q-layer';
+  let bestIndex = 0;
+  for (let i = 1; i < qVals.length; i++) {
+    if (qVals[i] > qVals[bestIndex]) bestIndex = i;
+  }
+  ACTIONS.forEach((action, index) => {
+    const value = qVals[index] ?? 0;
+    const el = document.createElement('div');
+    el.className = `q-value q-${action.key}`;
+    el.dataset.action = action.key;
+    el.dataset.value = Number.isFinite(value) ? value.toString() : '0';
+    el.textContent = `${action.symbol} ${Number.isFinite(value) ? value.toFixed(2) : '0.00'}`;
+    el.style.background = colorForValue(value, range);
+    if (index === bestIndex) {
+      el.classList.add('best');
+    }
+    layer.appendChild(el);
+  });
+  return layer;
+}
 
 export function initRenderer(environment, element, gridSize) {
   env = environment;
   gridEl = element;
   size = gridSize;
+  currentAgent = null;
   gridEl.style.setProperty('--size', size);
 }
 
-export function render(state) {
+export function render(state, agent) {
+  if (!gridEl || !env) return;
+  if (agent !== undefined) {
+    currentAgent = agent;
+  }
+  const activeAgent = currentAgent;
+  const { range } = activeAgent ? summarizeQValues(activeAgent, size) : { range: 0 };
   gridEl.innerHTML = '';
   for (let y = 0; y < size; y++) {
     for (let x = 0; x < size; x++) {
@@ -25,8 +158,12 @@ export function render(state) {
         if (x === size - 1 && y === size - 1) return;
         env.toggleObstacle(x, y);
         saveEnvironment(env);
-        render(env.getState());
+        render(env.getState(), currentAgent);
       });
+      if (activeAgent) {
+        const qVals = getCellQValues(activeAgent, x, y);
+        cell.appendChild(createQOverlay(qVals, range));
+      }
       gridEl.appendChild(cell);
     }
   }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -16,6 +16,8 @@ body {
   width: 40px;
   height: 40px;
   border: 1px solid #555;
+  position: relative;
+  overflow: hidden;
 }
 
 .agent {
@@ -28,6 +30,50 @@ body {
 
 .obstacle {
   background: #f44336;
+}
+
+.q-layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+  pointer-events: none;
+}
+
+.q-value {
+  font-size: 10px;
+  color: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  padding: 1px;
+  margin: 1px;
+  text-shadow: 0 0 3px #000;
+  pointer-events: none;
+}
+
+.q-value.q-up {
+  grid-area: 1 / 2 / 2 / 3;
+}
+
+.q-value.q-down {
+  grid-area: 3 / 2 / 4 / 3;
+}
+
+.q-value.q-left {
+  grid-area: 2 / 1 / 3 / 2;
+}
+
+.q-value.q-right {
+  grid-area: 2 / 3 / 3 / 4;
+}
+
+.q-value.best {
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.5);
 }
 
 button {

--- a/tests/test_render_grid.js
+++ b/tests/test_render_grid.js
@@ -1,0 +1,75 @@
+import { JSDOM } from 'jsdom';
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+import { initRenderer, render } from '../src/ui/renderGrid.js';
+
+export async function run(assert) {
+  const previousWindow = global.window;
+  const previousDocument = global.document;
+  const dom = new JSDOM(`<div id="grid"></div>`, { pretendToBeVisual: true });
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  try {
+    const gridEl = document.getElementById('grid');
+    const env = new GridWorldEnvironment(2);
+    initRenderer(env, gridEl, env.size);
+
+    const agent = {
+      qTable: new Map([
+        ['0,0', Float32Array.from([0.25, -0.5, 0.8, 0.1])],
+        ['1,0', Float32Array.from([-0.1, 0.3, -0.2, 0.9])]
+      ])
+    };
+
+    render(env.getState(), agent);
+
+    const cells = gridEl.querySelectorAll('.cell');
+    assert.strictEqual(cells.length, 4);
+
+    const cell00 = cells[0];
+    const left00 = cell00.querySelector('.q-value.q-left');
+    assert.ok(left00, 'left q-value should exist for cell (0,0)');
+    assert.strictEqual(left00.dataset.action, 'left');
+    assert.strictEqual(parseFloat(left00.dataset.value).toFixed(2), '0.80');
+    assert.strictEqual(cell00.querySelector('.q-value.best').dataset.action, 'left');
+
+    const down00 = cell00.querySelector('.q-value.q-down');
+    assert.ok(down00.textContent.includes('-0.50'));
+    if (down00.style.background.startsWith('rgba')) {
+      const components = down00.style.background.match(/\d+\.\d+|\d+/g) || [];
+      assert.ok(components.length >= 2, 'rgba color should provide at least red and green components');
+      const [r, g] = components.map(Number);
+      assert.ok(r >= g, 'negative q-value should emphasise red channel');
+    } else {
+      assert.ok(down00.style.background.startsWith('hsla(0'));
+    }
+
+    const cell10 = cells[1];
+    const right10 = cell10.querySelector('.q-value.q-right');
+    assert.ok(right10.textContent.includes('0.90'));
+    assert.strictEqual(parseFloat(right10.dataset.value).toFixed(2), '0.90');
+    assert.strictEqual(cell10.querySelector('.q-value.best').dataset.action, 'right');
+    if (right10.style.background.startsWith('rgba')) {
+      const components = right10.style.background.match(/\d+\.\d+|\d+/g) || [];
+      assert.ok(components.length >= 2, 'rgba color should provide at least red and green components');
+      const [r, g] = components.map(Number);
+      assert.ok(g >= r, 'positive q-value should emphasise green channel');
+    } else {
+      assert.ok(right10.style.background.startsWith('hsla(140'));
+    }
+
+    const up10 = cell10.querySelector('.q-value.q-up');
+    assert.ok(up10.textContent.includes('↑'));
+  } finally {
+    if (previousWindow === undefined) {
+      delete global.window;
+    } else {
+      global.window = previousWindow;
+    }
+    if (previousDocument === undefined) {
+      delete global.document;
+    } else {
+      global.document = previousDocument;
+    }
+  }
+}


### PR DESCRIPTION
## Context
- expose per-action Q-values in the grid so training progress is visible
- keep the visualization in sync with agent swaps, environment changes, and persistence operations

## Description
- pass the active agent into the grid renderer on every update
- render directional overlays that derive their magnitudes from the agent's current Q-table
- apply styling for the overlay elements and ensure environment interactions continue to refresh the view

## Changes
- enhanced `renderGrid` to compute normalized Q-values, highlight best actions, and handle agent references
- wired `render` calls in the UI to supply the trainer's agent and added CSS support for the new overlay
- added a jsdom-backed test that verifies Q-value text, highlighting, and colour heuristics for known states

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c8809ab5dc8332b64b3f5aed453e5d