### PR TITLE
feat: offload trainer to worker

### DIFF
--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -20,13 +20,25 @@ export function loadAgent(trainer, storage = globalThis.localStorage) {
   } else {
     agent = RLAgent.fromJSON(parsed);
   }
-  trainer.agent = agent;
+  Object.defineProperty(agent, '__factoryType', {
+    value: parsed.type || 'rl',
+    writable: true,
+    configurable: true,
+    enumerable: false
+  });
+  let assigned = agent;
+  if (typeof trainer.setAgent === 'function') {
+    const result = trainer.setAgent(agent);
+    assigned = result || trainer.agent;
+  } else {
+    trainer.agent = agent;
+  }
   if (typeof trainer.resetTrainerState === 'function') {
     trainer.resetTrainerState();
   } else {
     trainer.reset();
   }
-  return agent;
+  return assigned;
 }
 
 export function saveEnvironment(env, storage = globalThis.localStorage) {

--- a/src/rl/trainerWorker.js
+++ b/src/rl/trainerWorker.js
@@ -1,0 +1,106 @@
+import { GridWorldEnvironment } from './environment.js';
+import { RLTrainer } from './training.js';
+import { createAgent } from '../ui/agentFactory.js';
+
+let postToHost = null;
+
+const canUsePostMessage = typeof globalThis !== 'undefined'
+  && typeof globalThis.postMessage === 'function'
+  && typeof globalThis.addEventListener === 'function';
+
+if (canUsePostMessage) {
+  postToHost = data => globalThis.postMessage(data);
+  globalThis.addEventListener('message', event => {
+    handleMessage(event.data);
+  });
+} else {
+  let parentPort = null;
+  try {
+    ({ parentPort } = await import('node:worker_threads'));
+  } catch (err) {
+    parentPort = null;
+  }
+  if (!parentPort) {
+    throw new Error('trainerWorker: no messaging interface available');
+  }
+  postToHost = data => parentPort.postMessage(data);
+  parentPort.on('message', message => {
+    handleMessage(message);
+  });
+}
+
+let trainer = null;
+let agent = null;
+let environment = null;
+
+function emitProgress(state, reward, done, metrics) {
+  if (!trainer || !postToHost) return;
+  postToHost({
+    type: 'progress',
+    payload: {
+      state,
+      reward,
+      done,
+      metrics,
+      episodeRewards: trainer.episodeRewards.slice()
+    }
+  });
+}
+
+function configureTrainer(payload) {
+  if (!payload) return;
+  if (trainer) {
+    trainer.pause();
+  }
+  const envConfig = payload.env || {};
+  const agentConfig = payload.agent || {};
+  const trainerConfig = payload.trainer || {};
+  environment = new GridWorldEnvironment(envConfig.size ?? 5, envConfig.obstacles || []);
+  agent = createAgent(agentConfig.type || 'rl', agentConfig.params || {});
+  trainer = new RLTrainer(agent, environment, {
+    intervalMs: trainerConfig.intervalMs ?? 100,
+    onStep: (state, reward, done, metrics) => {
+      emitProgress(state, reward, done, metrics);
+    }
+  });
+  trainer.resetTrainerState();
+}
+
+function updateAgent(params) {
+  if (!agent || !params) return;
+  Object.assign(agent, params);
+  if (trainer) {
+    trainer.metrics.epsilon = agent.epsilon;
+    emitProgress(trainer.state, 0, false, { ...trainer.metrics });
+  }
+}
+
+function handleMessage(message) {
+  if (!message || typeof message !== 'object') return;
+  const { type, payload } = message;
+  switch (type) {
+    case 'config':
+      configureTrainer(payload);
+      break;
+    case 'start':
+      trainer?.start();
+      break;
+    case 'pause':
+      trainer?.pause();
+      break;
+    case 'reset':
+      trainer?.reset();
+      break;
+    case 'resetTrainerState':
+      trainer?.resetTrainerState();
+      break;
+    case 'interval':
+      if (trainer && typeof payload === 'number') {
+        trainer.setIntervalMs(payload);
+      }
+      break;
+    case 'agent:update':
+      updateAgent(payload);
+      break;
+  }
+}

--- a/src/ui/agentFactory.js
+++ b/src/ui/agentFactory.js
@@ -30,7 +30,15 @@ export function createAgent(type, options = {}) {
     lambda: 0
   };
   const AgentClass = agentFactory[type] || RLAgent;
-  return new AgentClass({ ...defaults, ...options });
+  const resolvedType = agentFactory[type] ? type : 'rl';
+  const agent = new AgentClass({ ...defaults, ...options });
+  Object.defineProperty(agent, '__factoryType', {
+    value: resolvedType,
+    writable: true,
+    configurable: true,
+    enumerable: false
+  });
+  return agent;
 }
 
 export { agentFactory };

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,10 +1,11 @@
 import { GridWorldEnvironment } from '../rl/environment.js';
-import { RLTrainer } from '../rl/training.js';
 import { LiveChart } from './liveChart.js';
 import { createAgent } from './agentFactory.js';
 import { initRenderer, render } from './renderGrid.js';
 import { bindControls } from './bindControls.js';
 import { saveEnvironment } from '../rl/storage.js';
+
+const supportsWorker = typeof Worker !== 'undefined';
 
 const gridEl = document.getElementById('grid');
 const gridSizeInput = document.getElementById('grid-size');
@@ -14,30 +15,58 @@ initRenderer(env, gridEl, env.size);
 const policySelect = document.getElementById('policy-select');
 const lambdaSlider = document.getElementById('lambda-slider');
 
-let agent = createAgent('rl', {
+let baseAgent = createAgent('rl', {
   policy: policySelect.value,
   lambda: parseFloat(lambdaSlider.value)
 });
 
 const liveChart = new LiveChart(document.getElementById('liveChart'));
-const trainer = new RLTrainer(agent, env, {
-  intervalMs: 100,
-  liveChart,
-  onStep: (state, reward, done, metrics) => {
-    render(state);
-    document.getElementById('episode').textContent = metrics.episode;
-    document.getElementById('steps').textContent = metrics.steps;
-    document.getElementById('reward').textContent = metrics.cumulativeReward.toFixed(2);
-    document.getElementById('epsilon').textContent = metrics.epsilon.toFixed(2);
+const metricsEls = {
+  episode: document.getElementById('episode'),
+  steps: document.getElementById('steps'),
+  reward: document.getElementById('reward'),
+  epsilon: document.getElementById('epsilon'),
+  epsilonSlider: document.getElementById('epsilon-slider'),
+  epsilonValue: document.getElementById('epsilon-value')
+};
 
-    document.getElementById('epsilon-slider').value = metrics.epsilon;
-    document.getElementById('epsilon-value').textContent = metrics.epsilon.toFixed(2);
-  }
-});
+function handleProgress(state, reward, done, metrics) {
+  render(state);
+  metricsEls.episode.textContent = metrics.episode;
+  metricsEls.steps.textContent = metrics.steps;
+  metricsEls.reward.textContent = metrics.cumulativeReward.toFixed(2);
+  metricsEls.epsilon.textContent = metrics.epsilon.toFixed(2);
+  metricsEls.epsilonSlider.value = metrics.epsilon;
+  metricsEls.epsilonValue.textContent = metrics.epsilon.toFixed(2);
+}
+
+let trainer;
+let agent;
+
+if (supportsWorker) {
+  trainer = createWorkerTrainer(baseAgent, env, {
+    intervalMs: 100,
+    liveChart,
+    onProgress: handleProgress
+  });
+  agent = trainer.agent;
+} else {
+  const { RLTrainer } = await import('../rl/training.js');
+  trainer = new RLTrainer(baseAgent, env, {
+    intervalMs: 100,
+    liveChart,
+    onStep: handleProgress
+  });
+  agent = baseAgent;
+}
 
 function rebuildEnvironment(size, obstacles = []) {
   env = new GridWorldEnvironment(size, obstacles);
-  trainer.env = env;
+  if (typeof trainer.setEnvironment === 'function') {
+    trainer.setEnvironment(env);
+  } else {
+    trainer.env = env;
+  }
   initRenderer(env, gridEl, size);
   trainer.reset();
   gridSizeInput.value = size;
@@ -52,3 +81,145 @@ gridSizeInput.addEventListener('change', e => {
 bindControls(trainer, agent, render, () => env, rebuildEnvironment);
 
 render(env.reset());
+
+function createWorkerTrainer(initialAgent, initialEnv, options) {
+  const worker = new Worker(new URL('../rl/trainerWorker.js', import.meta.url), { type: 'module' });
+  let currentEnv = initialEnv;
+  let rawAgent = initialAgent;
+  const metrics = {
+    episode: 1,
+    steps: 0,
+    cumulativeReward: 0,
+    epsilon: initialAgent.epsilon ?? 1
+  };
+  const trainerProxy = {
+    intervalMs: options.intervalMs ?? 100,
+    metrics,
+    state: typeof currentEnv.getState === 'function' ? currentEnv.getState() : null,
+    episodeRewards: [],
+    agent: null,
+    start() {
+      worker.postMessage({ type: 'start' });
+    },
+    pause() {
+      worker.postMessage({ type: 'pause' });
+    },
+    reset() {
+      worker.postMessage({ type: 'reset' });
+    },
+    resetTrainerState() {
+      worker.postMessage({ type: 'resetTrainerState' });
+    },
+    setIntervalMs(ms) {
+      this.intervalMs = ms;
+      worker.postMessage({ type: 'interval', payload: ms });
+    },
+    setAgent(newAgent) {
+      rawAgent = newAgent;
+      const proxy = wrapAgent(newAgent);
+      this.agent = proxy;
+      metrics.epsilon = newAgent.epsilon ?? metrics.epsilon;
+      sendConfig();
+      return proxy;
+    },
+    setEnvironment(newEnv) {
+      currentEnv = newEnv;
+      if (typeof newEnv.getState === 'function') {
+        this.state = newEnv.getState();
+      }
+      sendConfig();
+    }
+  };
+
+  function wrapAgent(agentInstance) {
+    return new Proxy(agentInstance, {
+      set(target, prop, value) {
+        target[prop] = value;
+        if (prop !== '__factoryType') {
+          worker.postMessage({
+            type: 'agent:update',
+            payload: { [prop]: value }
+          });
+        }
+        return true;
+      },
+      get(target, prop) {
+        return target[prop];
+      }
+    });
+  }
+
+  function serializeAgent(agentInstance) {
+    const fields = [
+      'epsilon',
+      'epsilonDecay',
+      'minEpsilon',
+      'policy',
+      'learningRate',
+      'lambda',
+      'gamma',
+      'temperature',
+      'ucbC',
+      'alphaCritic',
+      'alphaActor',
+      'alpha',
+      'beta',
+      'planningSteps',
+      'exploringStarts',
+      'initialValue'
+    ];
+    const params = {};
+    for (const key of fields) {
+      if (agentInstance[key] !== undefined) {
+        params[key] = agentInstance[key];
+      }
+    }
+    return params;
+  }
+
+  function cloneObstacles(obstacles) {
+    return (obstacles || []).map(o => ({ x: o.x, y: o.y }));
+  }
+
+  function sendConfig() {
+    worker.postMessage({
+      type: 'config',
+      payload: {
+        agent: {
+          type: rawAgent.__factoryType || 'rl',
+          params: serializeAgent(rawAgent)
+        },
+        env: {
+          size: currentEnv.size,
+          obstacles: cloneObstacles(currentEnv.obstacles)
+        },
+        trainer: {
+          intervalMs: trainerProxy.intervalMs
+        }
+      }
+    });
+  }
+
+  trainerProxy.agent = wrapAgent(rawAgent);
+  metrics.epsilon = rawAgent.epsilon ?? metrics.epsilon;
+
+  worker.onmessage = event => {
+    const { type, payload } = event.data || {};
+    if (type !== 'progress' || !payload) return;
+    trainerProxy.state = payload.state;
+    trainerProxy.episodeRewards = payload.episodeRewards || trainerProxy.episodeRewards;
+    if (payload.metrics) {
+      Object.assign(trainerProxy.metrics, payload.metrics);
+    }
+    if (typeof options.onProgress === 'function' && payload.metrics) {
+      options.onProgress(payload.state, payload.reward, payload.done, payload.metrics);
+    }
+    if (options.liveChart && payload.metrics) {
+      options.liveChart.push(payload.metrics.cumulativeReward, payload.metrics.epsilon);
+    }
+  };
+
+  sendConfig();
+
+  return trainerProxy;
+}

--- a/tests/test_trainer_worker.js
+++ b/tests/test_trainer_worker.js
@@ -1,0 +1,81 @@
+import { Worker } from 'node:worker_threads';
+
+function waitFor(worker, predicate, timeout = 1000) {
+  return new Promise((resolve, reject) => {
+    const removeListener = worker.off?.bind(worker) || worker.removeListener.bind(worker);
+    const timer = setTimeout(() => {
+      removeListener('message', onMessage);
+      reject(new Error('Timed out waiting for worker message'));
+    }, timeout);
+    const onMessage = message => {
+      try {
+        if (predicate(message)) {
+          clearTimeout(timer);
+          removeListener('message', onMessage);
+          resolve(message);
+        }
+      } catch (err) {
+        clearTimeout(timer);
+        removeListener('message', onMessage);
+        reject(err);
+      }
+    };
+    worker.on('message', onMessage);
+  });
+}
+
+export async function run(assert) {
+  const worker = new Worker(new URL('../src/rl/trainerWorker.js', import.meta.url), {
+    type: 'module'
+  });
+  try {
+    worker.postMessage({
+      type: 'config',
+      payload: {
+        agent: {
+          type: 'rl',
+          params: { epsilon: 0.5, learningRate: 0.1 }
+        },
+        env: {
+          size: 2,
+          obstacles: []
+        },
+        trainer: {
+          intervalMs: 5
+        }
+      }
+    });
+
+    const initial = await waitFor(
+      worker,
+      msg => msg.type === 'progress' && msg.payload.metrics.steps === 0
+    );
+    assert.strictEqual(initial.payload.metrics.episode, 1);
+    assert.strictEqual(initial.payload.metrics.cumulativeReward, 0);
+    assert.strictEqual(initial.payload.metrics.epsilon.toFixed(2), '0.50');
+
+    worker.postMessage({ type: 'start' });
+    const progressed = await waitFor(
+      worker,
+      msg => msg.type === 'progress' && msg.payload.metrics.steps > 0
+    );
+    assert.ok(progressed.payload.metrics.steps > 0);
+
+    worker.postMessage({ type: 'pause' });
+    worker.postMessage({ type: 'resetTrainerState' });
+    const reset = await waitFor(
+      worker,
+      msg => msg.type === 'progress' && msg.payload.metrics.steps === 0
+    );
+    assert.ok(reset.payload.metrics.episode >= 1);
+
+    worker.postMessage({ type: 'agent:update', payload: { epsilon: 0.25 } });
+    const updated = await waitFor(
+      worker,
+      msg => msg.type === 'progress' && msg.payload.metrics.epsilon <= 0.26
+    );
+    assert.strictEqual(updated.payload.metrics.epsilon.toFixed(2), '0.25');
+  } finally {
+    await worker.terminate();
+  }
+}


### PR DESCRIPTION
## Context
- Move the training loop off the main thread when possible while maintaining compatibility with existing controls and tests.

## Description
- Added a dedicated web worker script that instantiates `RLTrainer`, listens for control messages, and streams progress back to the UI.
- Updated the UI bootstrap and controls to proxy interactions through the worker when available while providing a synchronous fallback.
- Ensured live metrics, chart updates, and storage flows remain in sync across both execution modes and covered the worker bridge with tests.

## Changes
- introduce `src/rl/trainerWorker.js` with worker message handling for training lifecycle
- proxy UI controls in `index.js`/`bindControls.js` through a worker-aware trainer facade and preserve fallback behavior
- sync agent metadata for worker reconstruction via `agentFactory` and `storage`
- add `tests/test_trainer_worker.js` validating progress messaging from the worker

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c880adbe8c83328ee1db44c25f7154