### PR TITLE
fix: sync worker environment on obstacle changes

### DIFF
--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -10,7 +10,18 @@ const supportsWorker = typeof Worker !== 'undefined';
 const gridEl = document.getElementById('grid');
 const gridSizeInput = document.getElementById('grid-size');
 let env = new GridWorldEnvironment(parseInt(gridSizeInput.value, 10));
-initRenderer(env, gridEl, env.size);
+let trainer;
+let agent;
+
+function handleEnvironmentChange(updatedEnv = env) {
+  if (!trainer) return;
+  const nextEnv = updatedEnv || env;
+  if (typeof trainer.setEnvironment === 'function') {
+    trainer.setEnvironment(nextEnv);
+  }
+}
+
+initRenderer(env, gridEl, env.size, handleEnvironmentChange);
 
 const policySelect = document.getElementById('policy-select');
 const lambdaSlider = document.getElementById('lambda-slider');
@@ -40,9 +51,6 @@ function handleProgress(state, reward, done, metrics) {
   metricsEls.epsilonValue.textContent = metrics.epsilon.toFixed(2);
 }
 
-let trainer;
-let agent;
-
 if (supportsWorker) {
   trainer = createWorkerTrainer(baseAgent, env, {
     intervalMs: 100,
@@ -67,7 +75,7 @@ function rebuildEnvironment(size, obstacles = []) {
   } else {
     trainer.env = env;
   }
-  initRenderer(env, gridEl, size);
+  initRenderer(env, gridEl, size, handleEnvironmentChange);
   trainer.reset();
   gridSizeInput.value = size;
   saveEnvironment(env);

--- a/src/ui/renderGrid.js
+++ b/src/ui/renderGrid.js
@@ -3,11 +3,13 @@ import { saveEnvironment } from '../rl/storage.js';
 let env;
 let gridEl;
 let size;
+let onEnvironmentChange;
 
-export function initRenderer(environment, element, gridSize) {
+export function initRenderer(environment, element, gridSize, environmentChangeCallback = null) {
   env = environment;
   gridEl = element;
   size = gridSize;
+  onEnvironmentChange = environmentChangeCallback;
   gridEl.style.setProperty('--size', size);
 }
 
@@ -28,6 +30,9 @@ export function render(state) {
         if (x === size - 1 && y === size - 1) return;
         env.toggleObstacle(x, y);
         saveEnvironment(env);
+        if (typeof onEnvironmentChange === 'function') {
+          onEnvironmentChange(env);
+        }
         render(env.getState());
       });
       gridEl.appendChild(cell);

--- a/tests/test_render_grid.js
+++ b/tests/test_render_grid.js
@@ -41,7 +41,10 @@ export async function run(assert) {
   try {
     const gridEl = document.getElementById('grid');
     const env = new GridWorldEnvironment(2);
-    initRenderer(env, gridEl, env.size);
+    let environmentChanged = 0;
+    initRenderer(env, gridEl, env.size, () => {
+      environmentChanged += 1;
+    });
 
     const agent = {
       qTable: new Map([
@@ -68,6 +71,7 @@ export async function run(assert) {
     toggleCell.dispatchEvent(new dom.window.Event('click'));
     cells = gridEl.querySelectorAll('.cell');
     assert.ok(cells[1].classList.contains('obstacle'), 'clicked cell should toggle obstacle state');
+    assert.strictEqual(environmentChanged, 1, 'environment change callback should fire once');
   } finally {
     if (previousWindow === undefined) {
       delete global.window;


### PR DESCRIPTION
## Context
- Users reported that obstacles placed on the grid were ignored during training runs.

## Description
- Propagate obstacle toggles from the grid renderer back to the trainer so the worker environment stays in sync.
- Update the UI bootstrap logic to register an environment-change handler that notifies the trainer of obstacle edits.

## Changes
- Extend `initRenderer` with an optional environment-change callback and invoke it whenever a cell toggle occurs.
- Wire the grid renderer in `index.js` to call into the trainer so worker-based environments reload with the new obstacle layout.
- Cover the callback invocation with an updated renderer unit test.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c8b1ff4b6883328390722427b695ab