### PR TITLE
fix(worker): keep training running after environment updates

### DIFF
--- a/src/rl/environment.js
+++ b/src/rl/environment.js
@@ -1,10 +1,9 @@
 export class GridWorldEnvironment {
   constructor(size = 5, obstacles = []) {
     this.size = size;
-    this.obstacles = obstacles.map(o => ({ x: o.x, y: o.y }));
-    this.obstacleSet = new Set(
-      this.obstacles.map(o => `${o.x},${o.y}`)
-    );
+    this.obstacles = [];
+    this.obstacleSet = new Set();
+    this.setObstacles(obstacles);
     this.reset();
   }
 
@@ -32,6 +31,13 @@ export class GridWorldEnvironment {
       this.obstacles.push({ x, y });
       this.obstacleSet.add(key);
     }
+  }
+
+  setObstacles(obstacles = []) {
+    this.obstacles = obstacles.map(o => ({ x: o.x, y: o.y }));
+    this.obstacleSet = new Set(
+      this.obstacles.map(o => `${o.x},${o.y}`)
+    );
   }
 
   /**

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -94,6 +94,7 @@ function createWorkerTrainer(initialAgent, initialEnv, options) {
   const worker = new Worker(new URL('../rl/trainerWorker.js', import.meta.url), { type: 'module' });
   let currentEnv = initialEnv;
   let rawAgent = initialAgent;
+  let agentRevision = 0;
   const metrics = {
     episode: 1,
     steps: 0,
@@ -152,6 +153,7 @@ function createWorkerTrainer(initialAgent, initialEnv, options) {
     },
     setAgent(newAgent) {
       rawAgent = newAgent;
+      agentRevision += 1;
       const proxy = wrapAgent(newAgent);
       this.agent = proxy;
       metrics.epsilon = newAgent.epsilon ?? metrics.epsilon;
@@ -224,7 +226,8 @@ function createWorkerTrainer(initialAgent, initialEnv, options) {
       payload: {
         agent: {
           type: rawAgent.__factoryType || 'rl',
-          params: serializeAgent(rawAgent)
+          params: serializeAgent(rawAgent),
+          revision: agentRevision
         },
         env: {
           size: currentEnv.size,


### PR DESCRIPTION
## Context
- Obstacle edits in worker mode rebuilt the trainer with a fresh agent and never restarted training
- This silently halted training and discarded learned state, unlike the in-page trainer

## Description
- Track an agent revision so the worker only rebuilds the trainer when the agent truly changes
- Allow the worker to reuse the existing trainer and agent when only obstacles change, restarting if a rebuild was necessary
- Teach the environment to update its obstacle set without reallocating, and have the UI forward revision data
- Extend the worker test to verify training keeps progressing after an environment update while running

## Changes
- Add `setObstacles` to `GridWorldEnvironment`
- Rework `configureTrainer` in the worker to reuse state, restart only when required, and remember the agent revision
- Track the agent revision in the UI worker proxy and include it in config messages
- Expand `test_trainer_worker` to cover live obstacle edits without halting training

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c8b5099c208332b0d7bed50ed27e0e