### PR TITLE
feat: update replay priorities with td error

### DIFF
--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -141,6 +141,18 @@ export class RLAgent {
     this.decayEpsilon();
   }
 
+  /**
+   * Compute the temporal-difference error for a transition.
+   * Agents can override this to customize replay priority updates.
+   */
+  computeTdError(state, action, reward, nextState, done) {
+    const qVals = this._ensure(state);
+    const nextQ = this._ensure(nextState);
+    const maxNext = done ? 0 : Math.max(...nextQ);
+    const target = reward + this.gamma * maxNext;
+    return target - qVals[action];
+  }
+
   /** Reset agent to initial state. */
   reset() {
     this.epsilon = this.initialEpsilon;

--- a/tests/test_experience_replay.js
+++ b/tests/test_experience_replay.js
@@ -28,9 +28,15 @@ export async function run(testAssert) {
     constructor() {
       this.epsilon = 0;
       this.calls = [];
+      this.errorCalls = [];
+      this.tdErrorValue = 0.42;
     }
     act() {
       return 0;
+    }
+    computeTdError(...args) {
+      this.errorCalls.push(args);
+      return this.tdErrorValue;
     }
     async learn(...args) {
       this.calls.push(args);
@@ -49,4 +55,7 @@ export async function run(testAssert) {
   testAssert.strictEqual(replay.buffer.length, 1);
   testAssert.strictEqual(agent.calls.length, 2);
   testAssert.deepStrictEqual(agent.calls[0], agent.calls[1]);
+  testAssert.strictEqual(agent.errorCalls.length, 1);
+  testAssert.deepStrictEqual(agent.errorCalls[0], agent.calls[1]);
+  testAssert.strictEqual(replay.priorities[0], Math.abs(agent.tdErrorValue));
 }


### PR DESCRIPTION
## Context
- ensure prioritized replay buffers react to learning updates

## Description
- add a default `computeTdError` implementation to `RLAgent`
- update `RLTrainer` to compute TD errors during replay and refresh priorities
- expand experience replay tests to cover priority updates

## Changes
- implement temporal-difference calculation helpers for agents
- propagate TD error driven priority updates through the trainer
- verify priorities mutate after replay in `test_experience_replay`

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c8c3f33520833280c1262151baf557