### PR TITLE
feat: add configurable grid world rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ import { GridWorldEnvironment } from './src/rl/environment.js';
 import { ExpectedSarsaAgent } from './src/rl/expectedSarsaAgent.js';
 import { RLTrainer } from './src/rl/training.js';
 
-const env = new GridWorldEnvironment(5);
+const env = new GridWorldEnvironment(5, [], {
+  stepPenalty: -0.01,
+  obstaclePenalty: -0.1,
+  goalReward: 1
+});
 const agent = new ExpectedSarsaAgent({ epsilon: 0.2 });
 await RLTrainer.trainEpisodes(agent, env, 50, 50);
 ```
@@ -66,4 +70,4 @@ const restored = RLAgent.fromJSON(saved);
 ## Frontend Demo
 
 Open `index.html` in a browser to interact with the grid world. Use the Start, Pause and Reset buttons to control training and watch the agent improve.
-Use the Grid Size input to resize the environment and toggle cells to set obstacles. The Save and Load buttons persist both the agent and the environment layout in your browser.
+Use the Grid Size input to resize the environment, tweak the step and obstacle penalties, and adjust the goal reward to explore different incentive structures. Toggle cells to set obstacles. The Save and Load buttons persist both the agent and the environment layout in your browser.

--- a/index.html
+++ b/index.html
@@ -134,6 +134,18 @@
               <span class="control-label">Grid size</span>
               <input type="number" id="grid-size" min="2" max="20" value="5" class="control-input control-number">
             </label>
+            <label class="control-block" for="step-penalty">
+              <span class="control-label">Step penalty</span>
+              <input type="number" id="step-penalty" step="0.01" value="-0.01" class="control-input control-number">
+            </label>
+            <label class="control-block" for="obstacle-penalty">
+              <span class="control-label">Obstacle penalty</span>
+              <input type="number" id="obstacle-penalty" step="0.01" value="-0.1" class="control-input control-number">
+            </label>
+            <label class="control-block" for="goal-reward">
+              <span class="control-label">Goal reward</span>
+              <input type="number" id="goal-reward" step="0.01" value="1" class="control-input control-number">
+            </label>
           </div>
 
           <div class="button-row">

--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -42,12 +42,31 @@ export function loadAgent(trainer, storage = globalThis.localStorage) {
 }
 
 export function saveEnvironment(env, storage = globalThis.localStorage) {
-  const data = JSON.stringify({ size: env.size, obstacles: env.obstacles });
+  const rewards = typeof env.getRewardConfig === 'function'
+    ? env.getRewardConfig()
+    : {
+      stepPenalty: env.stepPenalty,
+      obstaclePenalty: env.obstaclePenalty,
+      goalReward: env.goalReward
+    };
+  const data = JSON.stringify({
+    size: env.size,
+    obstacles: env.obstacles,
+    rewards
+  });
   storage.setItem('environment', data);
 }
 
 export function loadEnvironment(storage = globalThis.localStorage) {
   const data = storage.getItem('environment');
   if (!data) return null;
-  return JSON.parse(data);
+  const parsed = JSON.parse(data);
+  const obstacles = Array.isArray(parsed.obstacles)
+    ? parsed.obstacles.map(o => ({ x: o.x, y: o.y }))
+    : [];
+  return {
+    size: parsed.size,
+    obstacles,
+    rewards: parsed.rewards
+  };
 }

--- a/tests/test_environment_storage.js
+++ b/tests/test_environment_storage.js
@@ -5,6 +5,9 @@ import { saveEnvironment, loadEnvironment } from '../src/rl/storage.js';
 export async function run(assert) {
   const html = fs.readFileSync('index.html', 'utf8');
   assert.ok(html.includes('id="grid-size"'));
+  assert.ok(html.includes('id="step-penalty"'));
+  assert.ok(html.includes('id="obstacle-penalty"'));
+  assert.ok(html.includes('id="goal-reward"'));
 
   const js = fs.readFileSync('src/ui/renderGrid.js', 'utf8');
   assert.ok(js.includes('saveEnvironment(env);'));
@@ -15,8 +18,16 @@ export async function run(assert) {
     getItem(k) { return this.data[k] ?? null; }
   };
 
-  const env = new GridWorldEnvironment(4, [{ x: 1, y: 1 }]);
+  const env = new GridWorldEnvironment(4, [{ x: 1, y: 1 }], {
+    stepPenalty: -0.25,
+    obstaclePenalty: -1,
+    goalReward: 3
+  });
   saveEnvironment(env, storage);
   const loaded = loadEnvironment(storage);
-  assert.deepStrictEqual(loaded, { size: 4, obstacles: [{ x: 1, y: 1 }] });
+  assert.deepStrictEqual(loaded, {
+    size: 4,
+    obstacles: [{ x: 1, y: 1 }],
+    rewards: { stepPenalty: -0.25, obstaclePenalty: -1, goalReward: 3 }
+  });
 }

--- a/tests/test_rl_environment.js
+++ b/tests/test_rl_environment.js
@@ -17,4 +17,30 @@ export async function run() {
   const key = Array.from(new Float32Array([0, 0])).join(',');
   const q = agent.qTable.get(key);
   assert.ok(q[3] >= q[2], 'Right action should have higher value than left');
+
+  const customEnv = new GridWorldEnvironment(2, [], {
+    stepPenalty: -0.5,
+    obstaclePenalty: -2,
+    goalReward: 5
+  });
+  assert.deepStrictEqual(customEnv.getRewardConfig(), {
+    stepPenalty: -0.5,
+    obstaclePenalty: -2,
+    goalReward: 5
+  });
+  customEnv.reset();
+  let stepResult = customEnv.step(3);
+  assert.strictEqual(stepResult.reward, -0.5);
+  assert.strictEqual(stepResult.done, false);
+  customEnv.reset();
+  customEnv.toggleObstacle(1, 0);
+  stepResult = customEnv.step(3);
+  assert.strictEqual(stepResult.reward, -2);
+  assert.strictEqual(stepResult.done, false);
+  customEnv.toggleObstacle(1, 0);
+  customEnv.reset();
+  customEnv.step(3);
+  stepResult = customEnv.step(1);
+  assert.strictEqual(stepResult.reward, 5);
+  assert.strictEqual(stepResult.done, true);
 }


### PR DESCRIPTION
## Context
- expose grid world reward settings for user control
- ensure worker trainer and persistence handle the new configuration

## Description
- add configurable reward parameters to `GridWorldEnvironment`
- update the UI, persistence, and worker bridge to surface and propagate the reward options
- adjust tests and docs for the new behavior

## Changes
- add `DEFAULT_REWARD_CONFIG`, `setRewardConfig`, and `getRewardConfig` helpers and use them in `GridWorldEnvironment`
- persist reward settings alongside grid size/obstacles and clone them through the worker configuration messages
- surface step penalty, obstacle penalty, and goal reward inputs in the UI and bind them through `bindControls`
- expand environment and storage tests to cover custom reward setups and ensure new controls exist

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c8c3fdc0c88332bc9368763b311033