### PR TITLE
feat: add replay buffer clearing

### DIFF
--- a/src/rl/experienceReplay.js
+++ b/src/rl/experienceReplay.js
@@ -9,6 +9,16 @@ export class ExperienceReplay {
     this.position = 0;
   }
 
+  get size() {
+    return this.buffer.length;
+  }
+
+  clear() {
+    this.buffer.length = 0;
+    this.priorities.length = 0;
+    this.position = 0;
+  }
+
   add(transition, priority = 1) {
     if (this.buffer.length < this.capacity) {
       this.buffer.push(transition);

--- a/src/rl/training.js
+++ b/src/rl/training.js
@@ -138,11 +138,17 @@ export class RLTrainer {
     if (typeof this.agent.reset === 'function') {
       this.agent.reset();
     }
+    if (this.replayBuffer && typeof this.replayBuffer.clear === 'function') {
+      this.replayBuffer.clear();
+    }
     this._initializeTrainerState();
   }
 
   resetTrainerState() {
     this.pause();
+    if (this.replayBuffer && typeof this.replayBuffer.clear === 'function') {
+      this.replayBuffer.clear();
+    }
     this._initializeTrainerState();
   }
 

--- a/tests/test_experience_replay.js
+++ b/tests/test_experience_replay.js
@@ -12,6 +12,19 @@ export async function run(testAssert) {
   const states = buffer.buffer.map(t => t.state).sort();
   testAssert.deepStrictEqual(states, [2, 3]);
 
+  // Size getter and clearing
+  const clearBuffer = new ExperienceReplay(3);
+  testAssert.strictEqual(clearBuffer.size, 0);
+  clearBuffer.add({ state: 'first', action: 0, reward: 0, nextState: 'second', done: false }, 1);
+  clearBuffer.add({ state: 'second', action: 1, reward: 1, nextState: 'third', done: false }, 2);
+  testAssert.strictEqual(clearBuffer.size, 2);
+  testAssert.strictEqual(clearBuffer.priorities.length, 2);
+  clearBuffer.clear();
+  testAssert.strictEqual(clearBuffer.size, 0);
+  testAssert.strictEqual(clearBuffer.buffer.length, 0);
+  testAssert.strictEqual(clearBuffer.priorities.length, 0);
+  testAssert.strictEqual(clearBuffer.position, 0);
+
   // Sampling strategies
   const stratBuffer = new ExperienceReplay(3);
   stratBuffer.add({ state: 'a' }, 0);
@@ -115,4 +128,28 @@ export async function run(testAssert) {
   testAssert.strictEqual(agent.errorCalls.length, 1);
   testAssert.deepStrictEqual(agent.errorCalls[0], agent.calls[2]);
   testAssert.strictEqual(replay.priorities[0], Math.abs(agent.tdErrorValue));
+
+  // Trainer reset clears replay buffer
+  const resetEnv = new GridWorldEnvironment(2);
+  const resetAgent = new StubAgent();
+  const resetReplay = new ExperienceReplay(5);
+  const resetTrainer = new RLTrainer(resetAgent, resetEnv, {
+    replayBuffer: resetReplay,
+    replaySamples: 1,
+    replayStrategy: 'uniform'
+  });
+  resetTrainer.state = resetEnv.reset();
+  await resetTrainer.step();
+  testAssert.ok(resetReplay.size > 0);
+  resetTrainer.reset();
+  testAssert.strictEqual(resetReplay.size, 0);
+  testAssert.strictEqual(resetReplay.priorities.length, 0);
+  testAssert.strictEqual(resetReplay.position, 0);
+
+  await resetTrainer.step();
+  testAssert.ok(resetReplay.size > 0);
+  resetTrainer.resetTrainerState();
+  testAssert.strictEqual(resetReplay.size, 0);
+  testAssert.strictEqual(resetReplay.priorities.length, 0);
+  testAssert.strictEqual(resetReplay.position, 0);
 }


### PR DESCRIPTION
## Context
The experience replay buffer needed a way to reset itself when training restarts and a simple way to inspect its population.

## Description
Implemented support for clearing replay buffers and exposing their current size, and integrated these capabilities with the trainer reset workflow.

## Changes
- Added a `size` getter and `clear()` helper to the replay buffer implementation.
- Updated trainer reset paths to empty attached replay buffers when invoked.
- Extended replay unit tests to cover buffer clearing, size reporting, and trainer reset behavior.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c8d3b9f9ac83329af66ad75d83c039