### PR TITLE
feat: add configurable environment scenarios

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,12 @@
               <input type="range" id="interval-slider" min="10" max="1000" step="10" value="100" class="control-slider">
             </div>
 
+            <label class="control-block" for="scenario-select">
+              <span class="control-label">Scenario</span>
+              <select id="scenario-select" class="control-input">
+                <option value="classic">Classic Grid</option>
+              </select>
+            </label>
             <label class="control-block" for="grid-size">
               <span class="control-label">Grid size</span>
               <input type="number" id="grid-size" min="2" max="20" value="5" class="control-input control-number">

--- a/src/rl/environment.js
+++ b/src/rl/environment.js
@@ -14,6 +14,7 @@ export class GridWorldEnvironment {
     this.size = size;
     this.obstacles = [];
     this.obstacleSet = new Set();
+    this.scenarioId = 'classic';
     this.setRewardConfig(rewardConfig);
     this.setObstacles(obstacles);
     this.reset();
@@ -28,6 +29,10 @@ export class GridWorldEnvironment {
   /** Convert the current agent position to state Float32Array. */
   getState() {
     return new Float32Array([this.agentPos.x, this.agentPos.y]);
+  }
+
+  getGoalPosition() {
+    return { x: this.size - 1, y: this.size - 1 };
   }
 
   isObstacle(x, y) {
@@ -70,6 +75,14 @@ export class GridWorldEnvironment {
     };
   }
 
+  calculateReward(newX, newY, done) {
+    return done ? this.goalReward : this.stepPenalty;
+  }
+
+  describeCell() {
+    return { classes: [] };
+  }
+
   /**
    * Step the environment with an action.
    * @param action 0:up,1:down,2:left,3:right
@@ -95,9 +108,9 @@ export class GridWorldEnvironment {
       return { state: this.getState(), reward: this.obstaclePenalty, done: false };
     }
     this.agentPos = { x: newX, y: newY };
-    const done =
-      this.agentPos.x === this.size - 1 && this.agentPos.y === this.size - 1;
-    const reward = done ? this.goalReward : this.stepPenalty;
+    const goal = this.getGoalPosition();
+    const done = this.agentPos.x === goal.x && this.agentPos.y === goal.y;
+    const reward = this.calculateReward(this.agentPos.x, this.agentPos.y, done);
     return { state: this.getState(), reward, done };
   }
 }

--- a/src/rl/environmentPresets.js
+++ b/src/rl/environmentPresets.js
@@ -1,0 +1,184 @@
+import { GridWorldEnvironment, DEFAULT_REWARD_CONFIG } from './environment.js';
+import { WindyGridEnvironment } from './windyGridEnvironment.js';
+import { MovingGoalEnvironment } from './movingGoalEnvironment.js';
+import { RewardGridEnvironment } from './rewardGridEnvironment.js';
+
+export const DEFAULT_SCENARIO_ID = 'classic';
+
+function cloneObstacles(obstacles = []) {
+  return obstacles.map(obstacle => ({ x: obstacle.x, y: obstacle.y }));
+}
+
+function deepClone(value) {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergeRewards(defaults = {}, overrides) {
+  const base = { ...DEFAULT_REWARD_CONFIG, ...defaults };
+  if (!overrides || typeof overrides !== 'object') {
+    return base;
+  }
+  const merged = { ...base };
+  for (const key of Object.keys(base)) {
+    if (overrides[key] !== undefined) {
+      const value = Number(overrides[key]);
+      if (Number.isFinite(value)) {
+        merged[key] = value;
+      }
+    }
+  }
+  return merged;
+}
+
+function createWindColumns(size) {
+  if (size <= 2) {
+    return [];
+  }
+  const middleStart = Math.max(1, Math.floor(size / 2) - 1);
+  const middleEnd = Math.min(size - 2, middleStart + 1);
+  const columns = [];
+  for (let x = middleStart; x <= middleEnd; x += 1) {
+    columns.push({
+      x,
+      offsets: [
+        { dx: 0, dy: -1, weight: 0.7 },
+        { dx: 1, dy: 0, weight: 0.2 },
+        { dx: 0, dy: 0, weight: 0.1 }
+      ]
+    });
+  }
+  if (size > 3) {
+    const gustColumn = Math.min(size - 2, middleEnd + 1);
+    columns.push({
+      x: gustColumn,
+      offsets: [
+        { dx: 0, dy: -1, weight: 0.5 },
+        { dx: -1, dy: -1, weight: 0.2 },
+        { dx: 0, dy: 0, weight: 0.3 }
+      ]
+    });
+  }
+  return columns;
+}
+
+function createMovingGoalPattern(size) {
+  const max = size - 1;
+  const mid = Math.max(0, Math.floor(max / 2));
+  const pattern = [
+    { x: max, y: max },
+    { x: max, y: 0 },
+    { x: 0, y: max },
+    { x: mid, y: mid }
+  ];
+  const unique = [];
+  const seen = new Set();
+  for (const pos of pattern) {
+    const key = `${pos.x},${pos.y}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(pos);
+  }
+  return unique;
+}
+
+function createRewardCells(size) {
+  const max = size - 1;
+  const mid = Math.max(0, Math.floor(max / 2));
+  const nearMid = Math.max(0, mid - 1);
+  return [
+    { x: mid, y: mid, reward: 0.4 },
+    { x: mid, y: nearMid, reward: 0.25 },
+    { x: nearMid, y: mid, reward: -0.3 },
+    { x: max, y: nearMid, reward: 0.6 }
+  ];
+}
+
+const scenarioDefinitions = [
+  {
+    id: 'classic',
+    label: 'Classic Grid',
+    description: 'Deterministic grid world with a static goal.',
+    defaultSize: 5,
+    defaultRewards: {},
+    defaultObstacles: () => [],
+    create: ({ size, obstacles, rewards }) => new GridWorldEnvironment(size, cloneObstacles(obstacles), rewards)
+  },
+  {
+    id: 'windy',
+    label: 'Windy Pass',
+    description: 'Stochastic wind columns push the agent off course.',
+    defaultSize: 7,
+    defaultRewards: { stepPenalty: -0.04, obstaclePenalty: -0.2 },
+    defaultScenarioConfig: size => ({ windColumns: createWindColumns(size) }),
+    create: ({ size, obstacles, rewards, scenarioConfig }) => {
+      const config = scenarioConfig?.windColumns ? scenarioConfig : { windColumns: createWindColumns(size) };
+      return new WindyGridEnvironment(size, cloneObstacles(obstacles), rewards, config.windColumns);
+    }
+  },
+  {
+    id: 'moving-goal',
+    label: 'Moving Target',
+    description: 'Goal positions cycle during an episode.',
+    defaultSize: 6,
+    defaultRewards: { stepPenalty: -0.02, goalReward: 1.2 },
+    defaultScenarioConfig: size => ({ goalPattern: createMovingGoalPattern(size), moveFrequency: 8 }),
+    create: ({ size, obstacles, rewards, scenarioConfig }) => new MovingGoalEnvironment(
+      size,
+      cloneObstacles(obstacles),
+      rewards,
+      scenarioConfig ?? { goalPattern: createMovingGoalPattern(size), moveFrequency: 8 }
+    )
+  },
+  {
+    id: 'reward-grid',
+    label: 'Treasure Fields',
+    description: 'Sparse rewards and penalties scattered across the map.',
+    defaultSize: 6,
+    defaultRewards: { obstaclePenalty: -0.15, goalReward: 1.5 },
+    defaultScenarioConfig: size => ({ rewardCells: createRewardCells(size) }),
+    create: ({ size, obstacles, rewards, scenarioConfig }) => new RewardGridEnvironment(
+      size,
+      cloneObstacles(obstacles),
+      rewards,
+      scenarioConfig?.rewardCells ?? createRewardCells(size)
+    )
+  }
+];
+
+const scenarioMap = new Map(scenarioDefinitions.map(scenario => [scenario.id, scenario]));
+
+function resolveScenarioOptions(scenario, options = {}) {
+  const rawSize = Number.isFinite(options.size) ? Math.trunc(options.size) : scenario.defaultSize ?? 5;
+  const size = Math.max(2, rawSize);
+  const rewards = mergeRewards(scenario.defaultRewards, options.rewards);
+  const obstacles = Array.isArray(options.obstacles)
+    ? cloneObstacles(options.obstacles)
+    : (typeof scenario.defaultObstacles === 'function'
+      ? cloneObstacles(scenario.defaultObstacles(size))
+      : cloneObstacles(scenario.defaultObstacles ?? []));
+  const scenarioConfig = options.scenarioConfig
+    ? deepClone(options.scenarioConfig)
+    : (typeof scenario.defaultScenarioConfig === 'function'
+      ? deepClone(scenario.defaultScenarioConfig(size))
+      : deepClone(scenario.defaultScenarioConfig));
+  return { size, rewards, obstacles, scenarioConfig };
+}
+
+export function getScenarioDefinitions() {
+  return scenarioDefinitions.map(({ id, label, description }) => ({ id, label, description }));
+}
+
+export function getScenarioById(id) {
+  return scenarioMap.get(id) ?? scenarioMap.get(DEFAULT_SCENARIO_ID);
+}
+
+export function createEnvironmentFromScenario(id, options = {}) {
+  const scenario = getScenarioById(id);
+  const resolved = resolveScenarioOptions(scenario, options);
+  const env = scenario.create(resolved);
+  env.scenarioId = scenario.id;
+  return env;
+}

--- a/src/rl/movingGoalEnvironment.js
+++ b/src/rl/movingGoalEnvironment.js
@@ -1,0 +1,147 @@
+import { GridWorldEnvironment } from './environment.js';
+
+function clamp(value, min, max) {
+  const intValue = Math.trunc(value);
+  if (!Number.isFinite(intValue)) return min;
+  if (intValue < min) return min;
+  if (intValue > max) return max;
+  return intValue;
+}
+
+function createDefaultPattern(size) {
+  const max = size - 1;
+  const mid = clamp(Math.floor(max / 2), 0, max);
+  const pattern = [
+    { x: max, y: max },
+    { x: max, y: 0 },
+    { x: 0, y: max },
+    { x: mid, y: mid }
+  ];
+  const unique = [];
+  const seen = new Set();
+  for (const pos of pattern) {
+    const key = `${pos.x},${pos.y}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(pos);
+  }
+  return unique;
+}
+
+function sanitizePattern(pattern = [], size) {
+  if (!Array.isArray(pattern) || pattern.length === 0) {
+    return createDefaultPattern(size);
+  }
+  const max = size - 1;
+  const unique = [];
+  const seen = new Set();
+  for (const pos of pattern) {
+    if (!pos) continue;
+    const x = clamp(pos.x, 0, max);
+    const y = clamp(pos.y, 0, max);
+    const key = `${x},${y}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push({ x, y });
+  }
+  return unique.length > 0 ? unique : createDefaultPattern(size);
+}
+
+export class MovingGoalEnvironment extends GridWorldEnvironment {
+  constructor(size = 5, obstacles = [], rewardConfig = {}, options = {}) {
+    super(size, obstacles, rewardConfig);
+    this.scenarioId = 'moving-goal';
+    this.goalPattern = [];
+    this.goalIndex = 0;
+    this.goalPos = super.getGoalPosition();
+    this.moveFrequency = 6;
+    this.stepCounter = 0;
+    this.applyScenarioOptions(options);
+  }
+
+  applyScenarioOptions(options = {}) {
+    const pattern = sanitizePattern(options.goalPattern, this.size);
+    this.goalPattern = pattern;
+    const frequency = Number(options.moveFrequency);
+    if (Number.isFinite(frequency) && frequency > 0) {
+      this.moveFrequency = Math.trunc(frequency);
+    }
+    const maxIndex = this.goalPattern.length - 1;
+    const providedIndex = Number(options.goalIndex);
+    if (Number.isFinite(providedIndex) && maxIndex >= 0) {
+      const normalized = ((Math.trunc(providedIndex) % this.goalPattern.length) + this.goalPattern.length) % this.goalPattern.length;
+      this.goalIndex = normalized;
+    } else {
+      this.goalIndex = 0;
+    }
+    this.goalPos = this.goalPattern[this.goalIndex] ?? super.getGoalPosition();
+  }
+
+  getGoalPosition() {
+    return this.goalPos ?? super.getGoalPosition();
+  }
+
+  advanceGoal() {
+    if (!this.goalPattern.length) {
+      return;
+    }
+    this.goalIndex = (this.goalIndex + 1) % this.goalPattern.length;
+    this.goalPos = this.goalPattern[this.goalIndex];
+  }
+
+  reset() {
+    this.stepCounter = 0;
+    if (!Array.isArray(this.goalPattern) || this.goalPattern.length === 0) {
+      this.goalPattern = sanitizePattern([], this.size);
+      this.goalIndex = 0;
+    }
+    this.goalPos = this.goalPattern[this.goalIndex] ?? super.getGoalPosition();
+    return super.reset();
+  }
+
+  step(action) {
+    const result = super.step(action);
+    this.stepCounter += 1;
+    if (result.done) {
+      this.advanceGoal();
+      this.stepCounter = 0;
+    } else if (this.moveFrequency > 0 && this.stepCounter % this.moveFrequency === 0) {
+      this.advanceGoal();
+    }
+    return result;
+  }
+
+  describeCell(x, y) {
+    const info = { ...super.describeCell(x, y) };
+    if (!Array.isArray(info.classes)) {
+      info.classes = [];
+    }
+    const goal = this.getGoalPosition();
+    if (x === goal.x && y === goal.y) {
+      info.classes = [...info.classes, 'moving-goal'];
+    } else if (this.goalPattern.some((pos, index) => index !== this.goalIndex && pos.x === x && pos.y === y)) {
+      info.classes = [...info.classes, 'future-goal'];
+    }
+    return info;
+  }
+
+  getScenarioConfig() {
+    return {
+      goalPattern: this.goalPattern.map(pos => ({ ...pos })),
+      moveFrequency: this.moveFrequency,
+      goalIndex: this.goalIndex
+    };
+  }
+
+  getScenarioMetadata() {
+    return {
+      id: this.scenarioId,
+      goal: this.getGoalPosition(),
+      futureGoals: this.goalPattern
+        .map((pos, index) => ({ ...pos, index }))
+        .filter(entry => entry.index !== this.goalIndex)
+    };
+  }
+}
+
+export default MovingGoalEnvironment;

--- a/src/rl/rewardGridEnvironment.js
+++ b/src/rl/rewardGridEnvironment.js
@@ -1,0 +1,82 @@
+import { GridWorldEnvironment } from './environment.js';
+
+function clamp(value, min, max) {
+  const intValue = Math.trunc(value);
+  if (!Number.isFinite(intValue)) return min;
+  if (intValue < min) return min;
+  if (intValue > max) return max;
+  return intValue;
+}
+
+function sanitizeRewards(cells = [], size) {
+  if (!Array.isArray(cells) || cells.length === 0) {
+    return [];
+  }
+  const max = size - 1;
+  const sanitized = new Map();
+  for (const cell of cells) {
+    if (!cell) continue;
+    const rewardValue = Number(cell.reward ?? cell.value);
+    if (!Number.isFinite(rewardValue)) continue;
+    const x = clamp(cell.x, 0, max);
+    const y = clamp(cell.y, 0, max);
+    const key = `${x},${y}`;
+    sanitized.set(key, { x, y, reward: rewardValue });
+  }
+  return Array.from(sanitized.values());
+}
+
+export class RewardGridEnvironment extends GridWorldEnvironment {
+  constructor(size = 5, obstacles = [], rewardConfig = {}, rewardCells = []) {
+    super(size, obstacles, rewardConfig);
+    this.scenarioId = 'reward-grid';
+    this.rewardMap = new Map();
+    this.rewardCells = [];
+    this.setRewardCells(rewardCells);
+  }
+
+  setRewardCells(cells = []) {
+    const sanitized = sanitizeRewards(cells, this.size);
+    this.rewardCells = sanitized.map(entry => ({ ...entry }));
+    this.rewardMap = new Map(sanitized.map(entry => [`${entry.x},${entry.y}`, entry.reward]));
+  }
+
+  calculateReward(newX, newY, done) {
+    const baseReward = super.calculateReward(newX, newY, done);
+    const key = `${newX},${newY}`;
+    const bonus = this.rewardMap.get(key) ?? 0;
+    return baseReward + bonus;
+  }
+
+  describeCell(x, y) {
+    const info = { ...super.describeCell(x, y) };
+    if (!Array.isArray(info.classes)) {
+      info.classes = [];
+    }
+    const key = `${x},${y}`;
+    if (this.rewardMap.has(key)) {
+      const reward = this.rewardMap.get(key);
+      info.classes = [
+        ...info.classes,
+        reward >= 0 ? 'reward-bonus' : 'reward-penalty'
+      ];
+      info.reward = reward;
+    }
+    return info;
+  }
+
+  getScenarioConfig() {
+    return {
+      rewardCells: this.rewardCells.map(entry => ({ ...entry }))
+    };
+  }
+
+  getScenarioMetadata() {
+    return {
+      id: this.scenarioId,
+      rewardCells: this.rewardCells.map(entry => ({ ...entry }))
+    };
+  }
+}
+
+export default RewardGridEnvironment;

--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -41,6 +41,21 @@ export function loadAgent(trainer, storage = globalThis.localStorage) {
   return assigned;
 }
 
+function cloneObstacles(obstacles = []) {
+  return obstacles.map(obstacle => ({ x: obstacle.x, y: obstacle.y }));
+}
+
+function cloneScenarioConfig(env) {
+  if (typeof env?.getScenarioConfig !== 'function') {
+    return undefined;
+  }
+  const config = env.getScenarioConfig();
+  if (config === undefined || config === null) {
+    return config;
+  }
+  return JSON.parse(JSON.stringify(config));
+}
+
 export function saveEnvironment(env, storage = globalThis.localStorage) {
   const rewards = typeof env.getRewardConfig === 'function'
     ? env.getRewardConfig()
@@ -51,8 +66,10 @@ export function saveEnvironment(env, storage = globalThis.localStorage) {
     };
   const data = JSON.stringify({
     size: env.size,
-    obstacles: env.obstacles,
-    rewards
+    obstacles: cloneObstacles(env.obstacles),
+    rewards,
+    scenarioId: env.scenarioId ?? 'classic',
+    scenarioConfig: cloneScenarioConfig(env)
   });
   storage.setItem('environment', data);
 }
@@ -67,6 +84,8 @@ export function loadEnvironment(storage = globalThis.localStorage) {
   return {
     size: parsed.size,
     obstacles,
-    rewards: parsed.rewards
+    rewards: parsed.rewards,
+    scenarioId: parsed.scenarioId ?? 'classic',
+    scenarioConfig: parsed.scenarioConfig
   };
 }

--- a/src/rl/windyGridEnvironment.js
+++ b/src/rl/windyGridEnvironment.js
@@ -1,0 +1,136 @@
+import { GridWorldEnvironment } from './environment.js';
+
+function clampCoordinate(value, max) {
+  const intValue = Math.trunc(value);
+  if (!Number.isFinite(intValue)) return 0;
+  if (intValue < 0) return 0;
+  if (intValue > max) return max;
+  return intValue;
+}
+
+function clampOffset(value, size) {
+  const intValue = Math.trunc(value);
+  if (!Number.isFinite(intValue)) return 0;
+  const limit = size - 1;
+  if (intValue < -limit) return -limit;
+  if (intValue > limit) return limit;
+  return intValue;
+}
+
+function normalizeWindColumns(columns = [], size = 5) {
+  const normalized = [];
+  for (const entry of columns) {
+    if (!entry) continue;
+    const x = clampCoordinate(entry.x, size - 1);
+    if (!Number.isInteger(x)) continue;
+    const offsets = Array.isArray(entry.offsets) ? entry.offsets : [];
+    const sanitizedOffsets = offsets
+      .map(offset => {
+        const weight = Number(offset?.weight ?? offset?.probability ?? 1);
+        if (!Number.isFinite(weight) || weight <= 0) {
+          return null;
+        }
+        const dx = clampOffset(offset?.dx ?? 0, size);
+        const dy = clampOffset(offset?.dy ?? 0, size);
+        return { dx, dy, weight };
+      })
+      .filter(Boolean);
+    if (sanitizedOffsets.length === 0) {
+      sanitizedOffsets.push({ dx: 0, dy: -1, weight: 1 });
+    }
+    const totalWeight = sanitizedOffsets.reduce((acc, cur) => acc + cur.weight, 0);
+    let cumulative = 0;
+    const distribution = sanitizedOffsets.map(offset => {
+      cumulative += offset.weight / totalWeight;
+      return { ...offset, threshold: cumulative };
+    });
+    normalized.push({ x, distribution, offsets: sanitizedOffsets.map(o => ({ dx: o.dx, dy: o.dy, weight: o.weight })) });
+  }
+  return normalized;
+}
+
+export class WindyGridEnvironment extends GridWorldEnvironment {
+  constructor(size = 5, obstacles = [], rewardConfig = {}, windColumns = []) {
+    super(size, obstacles, rewardConfig);
+    this.scenarioId = 'windy';
+    this.windMap = new Map();
+    this.rawWindConfig = [];
+    this.setWind(windColumns);
+  }
+
+  setWind(columns = []) {
+    const normalized = normalizeWindColumns(columns, this.size);
+    this.windMap = new Map(normalized.map(entry => [entry.x, entry.distribution]));
+    this.rawWindConfig = normalized.map(entry => ({ x: entry.x, offsets: entry.offsets }));
+  }
+
+  applyWind(x, y) {
+    const distribution = this.windMap.get(x);
+    if (!distribution || distribution.length === 0) {
+      return { x, y };
+    }
+    const rand = Math.random();
+    for (const entry of distribution) {
+      if (rand <= entry.threshold) {
+        const nextX = clampCoordinate(x + entry.dx, this.size - 1);
+        const nextY = clampCoordinate(y + entry.dy, this.size - 1);
+        return { x: nextX, y: nextY };
+      }
+    }
+    return { x, y };
+  }
+
+  step(action) {
+    let newX = this.agentPos.x;
+    let newY = this.agentPos.y;
+    switch (action) {
+      case 0:
+        if (newY > 0) newY -= 1;
+        break;
+      case 1:
+        if (newY < this.size - 1) newY += 1;
+        break;
+      case 2:
+        if (newX > 0) newX -= 1;
+        break;
+      case 3:
+        if (newX < this.size - 1) newX += 1;
+        break;
+    }
+    const drifted = this.applyWind(newX, newY);
+    newX = drifted.x;
+    newY = drifted.y;
+    if (this.isObstacle(newX, newY)) {
+      return { state: this.getState(), reward: this.obstaclePenalty, done: false };
+    }
+    this.agentPos = { x: newX, y: newY };
+    const goal = this.getGoalPosition();
+    const done = this.agentPos.x === goal.x && this.agentPos.y === goal.y;
+    const reward = this.calculateReward(this.agentPos.x, this.agentPos.y, done);
+    return { state: this.getState(), reward, done };
+  }
+
+  describeCell(x, y) {
+    const info = { ...super.describeCell(x, y) };
+    if (!Array.isArray(info.classes)) {
+      info.classes = [];
+    }
+    if (this.windMap.has(x)) {
+      info.classes = [...info.classes, 'wind-zone'];
+    }
+    return info;
+  }
+
+  getScenarioConfig() {
+    return { windColumns: this.rawWindConfig.map(entry => ({ x: entry.x, offsets: entry.offsets.map(o => ({ ...o })) })) };
+  }
+
+  getScenarioMetadata() {
+    return {
+      id: this.scenarioId,
+      windColumns: this.rawWindConfig.map(entry => ({ x: entry.x, offsets: entry.offsets.map(o => ({ ...o })) }))
+    };
+  }
+}
+
+export default WindyGridEnvironment;

--- a/src/ui/bindControls.js
+++ b/src/ui/bindControls.js
@@ -6,6 +6,7 @@ function getElements() {
   return {
     agentSelect: document.getElementById('agent-select'),
     policySelect: document.getElementById('policy-select'),
+    scenarioSelect: document.getElementById('scenario-select'),
     epsilonSlider: document.getElementById('epsilon-slider'),
     epsilonValue: document.getElementById('epsilon-value'),
     intervalSlider: document.getElementById('interval-slider'),
@@ -74,6 +75,9 @@ function initializeControls(trainer, agent, env, els) {
   els.epsilonSlider.value = agent.epsilon;
   els.epsilonValue.textContent = agent.epsilon.toFixed(2);
   els.policySelect.value = agent.policy;
+  if (els.scenarioSelect && env?.scenarioId) {
+    els.scenarioSelect.value = env.scenarioId;
+  }
   els.intervalSlider.value = trainer.intervalMs;
   els.intervalValue.textContent = trainer.intervalMs;
   updateLearningRateControl(agent, els);
@@ -160,12 +164,18 @@ function bindEnvironmentControls(trainer, els, getAgent, getEnv, setEnv) {
     const rewards = readRewardInputs(els, env);
     const size = env?.size ?? 5;
     const obstacles = env ? cloneObstacles(env.obstacles) : [];
-    setEnv(size, obstacles, rewards);
+    setEnv({ size, obstacles, rewards });
     initializeControls(trainer, getAgent(), getEnv(), els);
   };
   els.stepPenaltyInput.addEventListener('change', handleChange);
   els.obstaclePenaltyInput.addEventListener('change', handleChange);
   els.goalRewardInput.addEventListener('change', handleChange);
+  if (els.scenarioSelect) {
+    els.scenarioSelect.addEventListener('change', e => {
+      setEnv({ scenarioId: e.target.value, useDefaults: true });
+      initializeControls(trainer, getAgent(), getEnv(), els);
+    });
+  }
 }
 
 function bindPersistence(trainer, els, getAgent, setAgent, render, getEnv, setEnv) {
@@ -192,7 +202,13 @@ function bindPersistence(trainer, els, getAgent, setAgent, render, getEnv, setEn
     initializeControls(trainer, assigned, getEnv(), els);
     const envData = loadEnvironment();
     if (envData) {
-      setEnv(envData.size, envData.obstacles, envData.rewards);
+      setEnv({
+        size: envData.size,
+        obstacles: envData.obstacles,
+        rewards: envData.rewards,
+        scenarioId: envData.scenarioId,
+        scenarioConfig: envData.scenarioConfig
+      });
       initializeControls(trainer, getAgent(), getEnv(), els);
     }
     render(trainer.state);

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -371,6 +371,8 @@ function createWorkerTrainer(initialAgent, initialEnv, options) {
 
   function sendConfig() {
     const rewards = cloneRewardConfig(getEnvRewardConfig(currentEnv));
+    const scenarioId = currentEnv?.scenarioId ?? DEFAULT_SCENARIO_ID;
+    const scenarioConfig = cloneScenarioConfig(currentEnv);
     worker.postMessage({
       type: 'config',
       payload: {
@@ -380,9 +382,11 @@ function createWorkerTrainer(initialAgent, initialEnv, options) {
           revision: agentRevision
         },
         env: {
+          scenarioId,
           size: currentEnv.size,
           obstacles: cloneObstacles(currentEnv.obstacles),
-          ...(rewards ? { rewards } : {})
+          ...(rewards ? { rewards } : {}),
+          ...(scenarioConfig !== undefined ? { scenarioConfig } : {})
         },
         trainer: {
           intervalMs: trainerProxy.intervalMs

--- a/src/ui/renderGrid.js
+++ b/src/ui/renderGrid.js
@@ -5,6 +5,41 @@ let gridEl;
 let size;
 let onEnvironmentChange;
 
+function getGoalPosition(environment, gridSize) {
+  if (environment && typeof environment.getGoalPosition === 'function') {
+    const goal = environment.getGoalPosition();
+    if (goal && Number.isFinite(goal.x) && Number.isFinite(goal.y)) {
+      return goal;
+    }
+  }
+  const fallback = gridSize - 1;
+  return { x: fallback, y: fallback };
+}
+
+function applyCellMetadata(cell, metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    cell.removeAttribute('data-reward');
+    return;
+  }
+  if (Array.isArray(metadata.classes)) {
+    for (const cls of metadata.classes) {
+      if (typeof cls === 'string' && cls) {
+        cell.classList.add(cls);
+      }
+    }
+  }
+  if (metadata.reward !== undefined) {
+    const rewardValue = Number(metadata.reward);
+    if (Number.isFinite(rewardValue)) {
+      cell.dataset.reward = rewardValue.toFixed(2);
+    } else {
+      cell.removeAttribute('data-reward');
+    }
+  } else {
+    cell.removeAttribute('data-reward');
+  }
+}
+
 export function initRenderer(environment, element, gridSize, environmentChangeCallback = null) {
   env = environment;
   gridEl = element;
@@ -17,6 +52,7 @@ export function render(state) {
   if (!gridEl || !env) return;
   const position = state ?? (typeof env.getState === 'function' ? env.getState() : null);
   if (!position) return;
+  const goal = getGoalPosition(env, size);
   gridEl.innerHTML = '';
   for (let y = 0; y < size; y++) {
     for (let x = 0; x < size; x++) {
@@ -24,10 +60,12 @@ export function render(state) {
       cell.className = 'cell';
       if (env.isObstacle(x, y)) cell.classList.add('obstacle');
       if (x === position[0] && y === position[1]) cell.classList.add('agent');
-      if (x === size - 1 && y === size - 1) cell.classList.add('goal');
+      if (x === goal.x && y === goal.y) cell.classList.add('goal');
+      const metadata = typeof env.describeCell === 'function' ? env.describeCell(x, y) : null;
+      applyCellMetadata(cell, metadata);
       cell.addEventListener('click', () => {
         if (x === env.agentPos.x && y === env.agentPos.y) return;
-        if (x === size - 1 && y === size - 1) return;
+        if (x === goal.x && y === goal.y) return;
         env.toggleObstacle(x, y);
         saveEnvironment(env);
         if (typeof onEnvironmentChange === 'function') {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -252,6 +252,65 @@ p {
   box-shadow: inset 0 0 12px rgba(30, 10, 20, 0.6), 0 0 14px rgba(248, 113, 113, 0.5);
 }
 
+.cell.wind-zone:not(.goal):not(.obstacle) {
+  background: linear-gradient(135deg, rgba(12, 74, 110, 0.82), rgba(15, 23, 42, 0.55));
+}
+
+.cell.wind-zone:not(.goal):not(.obstacle)::before {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 10px;
+  border: 1px dashed rgba(125, 211, 252, 0.45);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(14, 116, 144, 0.12));
+  pointer-events: none;
+}
+
+.cell.goal.moving-goal {
+  animation: movingGoalPulse 1.8s ease-in-out infinite alternate;
+  box-shadow: inset 0 0 14px rgba(15, 23, 42, 0.5), 0 0 24px rgba(129, 140, 248, 0.75);
+}
+
+@keyframes movingGoalPulse {
+  0% {
+    filter: drop-shadow(0 0 0 rgba(56, 189, 248, 0.25));
+  }
+  100% {
+    filter: drop-shadow(0 0 10px rgba(56, 189, 248, 0.45));
+  }
+}
+
+.cell.future-goal {
+  box-shadow: inset 0 0 0 2px rgba(129, 140, 248, 0.6);
+}
+
+.cell.reward-bonus::after,
+.cell.reward-penalty::after {
+  content: attr(data-reward);
+  position: absolute;
+  inset: 6px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  pointer-events: none;
+  letter-spacing: 0.02em;
+}
+
+.cell.reward-bonus::after {
+  background: rgba(34, 197, 94, 0.22);
+  border: 1px dashed rgba(34, 197, 94, 0.4);
+  color: #bbf7d0;
+}
+
+.cell.reward-penalty::after {
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px dashed rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+}
+
 .metrics-grid {
   display: grid;
   gap: 1rem;

--- a/tests/test_environment_storage.js
+++ b/tests/test_environment_storage.js
@@ -8,6 +8,7 @@ export async function run(assert) {
   assert.ok(html.includes('id="step-penalty"'));
   assert.ok(html.includes('id="obstacle-penalty"'));
   assert.ok(html.includes('id="goal-reward"'));
+  assert.ok(html.includes('id="scenario-select"'));
 
   const js = fs.readFileSync('src/ui/renderGrid.js', 'utf8');
   assert.ok(js.includes('saveEnvironment(env);'));
@@ -28,6 +29,8 @@ export async function run(assert) {
   assert.deepStrictEqual(loaded, {
     size: 4,
     obstacles: [{ x: 1, y: 1 }],
-    rewards: { stepPenalty: -0.25, obstaclePenalty: -1, goalReward: 3 }
+    rewards: { stepPenalty: -0.25, obstaclePenalty: -1, goalReward: 3 },
+    scenarioId: 'classic',
+    scenarioConfig: undefined
   });
 }

--- a/tests/test_scenario_storage.js
+++ b/tests/test_scenario_storage.js
@@ -1,0 +1,75 @@
+import { createEnvironmentFromScenario } from '../src/rl/environmentPresets.js';
+import { saveEnvironment, loadEnvironment } from '../src/rl/storage.js';
+
+function createStorage() {
+  const store = new Map();
+  return {
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    }
+  };
+}
+
+export async function run(assert) {
+  const windyEnv = createEnvironmentFromScenario('windy');
+  const windyStorage = createStorage();
+  saveEnvironment(windyEnv, windyStorage);
+  const loadedWindy = loadEnvironment(windyStorage);
+  assert.strictEqual(loadedWindy.scenarioId, 'windy');
+  assert.ok(Array.isArray(loadedWindy.scenarioConfig.windColumns));
+  assert.ok(loadedWindy.scenarioConfig.windColumns.length > 0);
+  const windyRehydrated = createEnvironmentFromScenario(loadedWindy.scenarioId, {
+    size: loadedWindy.size,
+    obstacles: loadedWindy.obstacles,
+    rewards: loadedWindy.rewards,
+    scenarioConfig: loadedWindy.scenarioConfig
+  });
+  const firstWindColumn = loadedWindy.scenarioConfig.windColumns[0];
+  const windyMetadata = windyRehydrated.describeCell(firstWindColumn.x, 0);
+  assert.ok(Array.isArray(windyMetadata.classes) && windyMetadata.classes.includes('wind-zone'));
+
+  const movingEnv = createEnvironmentFromScenario('moving-goal');
+  const movingStorage = createStorage();
+  saveEnvironment(movingEnv, movingStorage);
+  const loadedMoving = loadEnvironment(movingStorage);
+  assert.strictEqual(loadedMoving.scenarioId, 'moving-goal');
+  assert.ok(Array.isArray(loadedMoving.scenarioConfig.goalPattern));
+  assert.ok(loadedMoving.scenarioConfig.goalPattern.length > 0);
+  const movingRehydrated = createEnvironmentFromScenario(loadedMoving.scenarioId, {
+    size: loadedMoving.size,
+    obstacles: loadedMoving.obstacles,
+    rewards: loadedMoving.rewards,
+    scenarioConfig: loadedMoving.scenarioConfig
+  });
+  const goal = movingRehydrated.getGoalPosition();
+  assert.ok(loadedMoving.scenarioConfig.goalPattern.some(pos => pos.x === goal.x && pos.y === goal.y));
+
+  const rewardEnv = createEnvironmentFromScenario('reward-grid');
+  const rewardStorage = createStorage();
+  saveEnvironment(rewardEnv, rewardStorage);
+  const loadedReward = loadEnvironment(rewardStorage);
+  assert.strictEqual(loadedReward.scenarioId, 'reward-grid');
+  assert.ok(Array.isArray(loadedReward.scenarioConfig.rewardCells));
+  assert.ok(loadedReward.scenarioConfig.rewardCells.length > 0);
+  const rewardRehydrated = createEnvironmentFromScenario(loadedReward.scenarioId, {
+    size: loadedReward.size,
+    obstacles: loadedReward.obstacles,
+    rewards: loadedReward.rewards,
+    scenarioConfig: loadedReward.scenarioConfig
+  });
+  const rewardCell = loadedReward.scenarioConfig.rewardCells[0];
+  const rewardMetadata = rewardRehydrated.describeCell(rewardCell.x, rewardCell.y);
+  assert.ok(Array.isArray(rewardMetadata.classes));
+  const expectedClass = rewardCell.reward >= 0 ? 'reward-bonus' : 'reward-penalty';
+  assert.ok(rewardMetadata.classes.includes(expectedClass));
+  assert.strictEqual(rewardMetadata.reward, rewardCell.reward);
+}


### PR DESCRIPTION
## Context
- add richer grid world scenarios with stochastic transitions and dynamic goals

## Description
- introduce environment presets and new GridWorldEnvironment subclasses for wind, moving goals, and per-cell rewards
- update UI to select scenarios, highlight special tiles, and persist selection via storage hooks
- expand regression coverage to verify scenario serialization/deserialization and control synchronization

## Changes
- created environmentPresets along with windy, moving goal, and reward grid environment classes exposing scenario metadata
- wired scenario selection into index UI, renderer, styles, and storage with updated controls
- added tests for scenario persistence plus adjustments to existing environment storage expectations

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68c9fb4c8ea483328e97f789994e8998