### PR TITLE
feat: add planner agents and environment model helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,8 @@
                 <option value="dyna">Dyna-Q</option>
                 <option value="ac">Actor-Critic</option>
                 <option value="optimistic">Optimistic</option>
+                <option value="value-iteration">Value Iteration</option>
+                <option value="policy-iteration">Policy Iteration</option>
               </select>
             </label>
 

--- a/src/rl/plannerAgent.js
+++ b/src/rl/plannerAgent.js
@@ -1,0 +1,54 @@
+import { RLAgent } from './agent.js';
+
+export class PlannerAgent extends RLAgent {
+  constructor(options = {}) {
+    super({
+      ...options,
+      epsilon: 0,
+      epsilonDecay: 1,
+      minEpsilon: 0
+    });
+    this.initialEpsilon = 0;
+    this.epsilon = 0;
+    this.learningRate = undefined;
+    this.policyMap = new Map();
+    this.valueFunction = new Map();
+    this.environment = null;
+  }
+
+  setEnvironment(environment) {
+    this.environment = environment || null;
+  }
+
+  reset(environment) {
+    if (environment) {
+      this.setEnvironment(environment);
+    }
+    super.reset();
+    this.epsilon = 0;
+    this.policyMap.clear();
+    this.valueFunction.clear();
+    if (this.environment) {
+      this.planPolicy(this.environment);
+    }
+  }
+
+  planPolicy() {
+    throw new Error('planPolicy() must be implemented by planner agents');
+  }
+
+  act(state) {
+    const key = this._key(state);
+    if (!this.policyMap.has(key) && this.environment) {
+      this.planPolicy(this.environment);
+    }
+    if (!this.policyMap.has(key)) {
+      return 0;
+    }
+    return this.policyMap.get(key);
+  }
+
+  learn() {
+    return 0;
+  }
+}

--- a/src/rl/policyIterationAgent.js
+++ b/src/rl/policyIterationAgent.js
@@ -1,0 +1,124 @@
+import { PlannerAgent } from './plannerAgent.js';
+
+export class PolicyIterationAgent extends PlannerAgent {
+  constructor(options = {}) {
+    super(options);
+    this.evaluationTolerance = options.theta ?? options.evaluationTolerance ?? 1e-4;
+    this.maxEvaluationIterations = options.maxEvaluationIterations ?? 100;
+    this.maxPolicyIterations = options.maxPolicyIterations ?? 100;
+  }
+
+  planPolicy(environment = this.environment) {
+    if (!environment) return;
+    const states = environment.enumerateStates();
+    if (states.length === 0) {
+      this.policyMap.clear();
+      this.valueFunction.clear();
+      return;
+    }
+    const actions = environment.getAvailableActions();
+    let policy = new Map(this.policyMap);
+    for (const state of states) {
+      const key = this._key(state);
+      if (environment.isTerminalState(state)) {
+        policy.set(key, 0);
+        continue;
+      }
+      if (!policy.has(key)) {
+        policy.set(key, actions[0] ?? 0);
+      }
+    }
+    let values = new Map(this.valueFunction);
+    for (const state of states) {
+      const key = this._key(state);
+      if (!values.has(key)) {
+        values.set(key, 0);
+      }
+    }
+    let isStable = false;
+    let iterations = 0;
+    while (!isStable && iterations < this.maxPolicyIterations) {
+      values = this._evaluatePolicy(environment, states, actions, policy, values);
+      isStable = this._improvePolicy(environment, states, actions, policy, values);
+      iterations += 1;
+    }
+    this.policyMap = new Map(policy);
+    this.valueFunction = new Map(values);
+  }
+
+  _evaluatePolicy(environment, states, actions, policy, initialValues) {
+    let values = new Map(initialValues);
+    let iterations = 0;
+    let delta = Infinity;
+    while (delta > this.evaluationTolerance && iterations < this.maxEvaluationIterations) {
+      const updated = new Map(values);
+      delta = 0;
+      for (const state of states) {
+        const key = this._key(state);
+        if (environment.isTerminalState(state)) {
+          updated.set(key, 0);
+          continue;
+        }
+        const action = policy.get(key) ?? actions[0] ?? 0;
+        const transition = environment.getTransition(state, action);
+        const nextKey = this._key(transition.state);
+        const nextValue = values.get(nextKey) ?? 0;
+        const newValue = transition.reward + this.gamma * (transition.done ? 0 : nextValue);
+        const previous = values.get(key) ?? 0;
+        updated.set(key, newValue);
+        delta = Math.max(delta, Math.abs(newValue - previous));
+      }
+      values = updated;
+      iterations += 1;
+    }
+    return values;
+  }
+
+  _improvePolicy(environment, states, actions, policy, values) {
+    let stable = true;
+    for (const state of states) {
+      const key = this._key(state);
+      if (environment.isTerminalState(state)) {
+        policy.set(key, 0);
+        continue;
+      }
+      const currentAction = policy.get(key) ?? actions[0] ?? 0;
+      let bestAction = currentAction;
+      let bestValue = -Infinity;
+      for (const action of actions) {
+        const transition = environment.getTransition(state, action);
+        const nextKey = this._key(transition.state);
+        const nextValue = values.get(nextKey) ?? 0;
+        const candidate = transition.reward + this.gamma * (transition.done ? 0 : nextValue);
+        if (candidate > bestValue) {
+          bestValue = candidate;
+          bestAction = action;
+        }
+      }
+      if (bestAction !== currentAction) {
+        stable = false;
+      }
+      policy.set(key, bestAction);
+    }
+    return stable;
+  }
+
+  toJSON() {
+    return {
+      type: 'policy-iteration',
+      gamma: this.gamma,
+      theta: this.evaluationTolerance,
+      maxEvaluationIterations: this.maxEvaluationIterations,
+      maxPolicyIterations: this.maxPolicyIterations
+    };
+  }
+
+  static fromJSON(data = {}) {
+    return new PolicyIterationAgent({
+      gamma: data.gamma,
+      theta: data.theta,
+      maxEvaluationIterations: data.maxEvaluationIterations,
+      maxPolicyIterations: data.maxPolicyIterations
+    });
+  }
+}

--- a/src/rl/storage.js
+++ b/src/rl/storage.js
@@ -2,6 +2,8 @@ import { RLAgent } from './agent.js';
 import { RLTrainer } from './training.js';
 import { DoubleQAgent } from './doubleQAgent.js';
 import { OptimisticAgent } from './optimisticAgent.js';
+import { ValueIterationAgent } from './valueIterationAgent.js';
+import { PolicyIterationAgent } from './policyIterationAgent.js';
 
 export function saveAgent(agent, storage = globalThis.localStorage) {
   const data = JSON.stringify(agent.toJSON());
@@ -17,6 +19,10 @@ export function loadAgent(trainer, storage = globalThis.localStorage) {
     agent = DoubleQAgent.fromJSON(parsed);
   } else if (parsed.type === 'optimistic') {
     agent = OptimisticAgent.fromJSON(parsed);
+  } else if (parsed.type === 'value-iteration') {
+    agent = ValueIterationAgent.fromJSON(parsed);
+  } else if (parsed.type === 'policy-iteration') {
+    agent = PolicyIterationAgent.fromJSON(parsed);
   } else {
     agent = RLAgent.fromJSON(parsed);
   }

--- a/src/rl/training.js
+++ b/src/rl/training.js
@@ -31,6 +31,13 @@ export class RLTrainer {
     this.metricsTracker = new MetricsTracker(this.agent);
     this.metrics = this.metricsTracker.data;
     this.episodeRewards = this.metricsTracker.episodeRewards;
+    this._assignEnvironmentToAgent();
+  }
+
+  _assignEnvironmentToAgent() {
+    if (this.agent && typeof this.agent.setEnvironment === 'function') {
+      this.agent.setEnvironment(this.env);
+    }
   }
 
   _clearReplayBuffer() {
@@ -63,8 +70,9 @@ export class RLTrainer {
 
   _resetInternal({ resetAgent }) {
     this.pause();
+    this._assignEnvironmentToAgent();
     if (resetAgent && typeof this.agent.reset === 'function') {
-      this.agent.reset();
+      this.agent.reset(this.env);
     }
     this._clearReplayBuffer();
     this._initializeTrainerState();

--- a/src/rl/valueIterationAgent.js
+++ b/src/rl/valueIterationAgent.js
@@ -1,0 +1,95 @@
+import { PlannerAgent } from './plannerAgent.js';
+
+export class ValueIterationAgent extends PlannerAgent {
+  constructor(options = {}) {
+    super(options);
+    this.convergenceTolerance = options.theta ?? options.convergenceTolerance ?? 1e-4;
+    this.maxIterations = options.maxIterations ?? 1000;
+  }
+
+  planPolicy(environment = this.environment) {
+    if (!environment) return;
+    const states = environment.enumerateStates();
+    if (states.length === 0) {
+      this.policyMap.clear();
+      this.valueFunction.clear();
+      return;
+    }
+    const actions = environment.getAvailableActions();
+    let values = new Map(this.valueFunction);
+    for (const state of states) {
+      const key = this._key(state);
+      if (!values.has(key)) {
+        values.set(key, 0);
+      }
+    }
+    let iterations = 0;
+    let delta = Infinity;
+    while (delta > this.convergenceTolerance && iterations < this.maxIterations) {
+      const updatedValues = new Map(values);
+      delta = 0;
+      for (const state of states) {
+        const key = this._key(state);
+        if (environment.isTerminalState(state)) {
+          updatedValues.set(key, 0);
+          continue;
+        }
+        let bestValue = -Infinity;
+        for (const action of actions) {
+          const transition = environment.getTransition(state, action);
+          const nextKey = this._key(transition.state);
+          const nextValue = values.get(nextKey) ?? 0;
+          const candidate = transition.reward + this.gamma * (transition.done ? 0 : nextValue);
+          if (candidate > bestValue) {
+            bestValue = candidate;
+          }
+        }
+        const newValue = bestValue === -Infinity ? 0 : bestValue;
+        const previous = values.get(key) ?? 0;
+        updatedValues.set(key, newValue);
+        delta = Math.max(delta, Math.abs(newValue - previous));
+      }
+      values = updatedValues;
+      iterations += 1;
+    }
+    this.valueFunction = values;
+    this.policyMap = new Map();
+    for (const state of states) {
+      const key = this._key(state);
+      if (environment.isTerminalState(state)) {
+        this.policyMap.set(key, 0);
+        continue;
+      }
+      let bestAction = 0;
+      let bestValue = -Infinity;
+      for (const action of actions) {
+        const transition = environment.getTransition(state, action);
+        const nextKey = this._key(transition.state);
+        const nextValue = this.valueFunction.get(nextKey) ?? 0;
+        const candidate = transition.reward + this.gamma * (transition.done ? 0 : nextValue);
+        if (candidate > bestValue) {
+          bestValue = candidate;
+          bestAction = action;
+        }
+      }
+      this.policyMap.set(key, bestAction);
+    }
+  }
+
+  toJSON() {
+    return {
+      type: 'value-iteration',
+      gamma: this.gamma,
+      theta: this.convergenceTolerance,
+      maxIterations: this.maxIterations
+    };
+  }
+
+  static fromJSON(data = {}) {
+    return new ValueIterationAgent({
+      gamma: data.gamma,
+      theta: data.theta,
+      maxIterations: data.maxIterations
+    });
+  }
+}

--- a/src/ui/agentFactory.js
+++ b/src/ui/agentFactory.js
@@ -8,6 +8,8 @@ import { MonteCarloAgent } from '../rl/monteCarloAgent.js';
 import { ActorCriticAgent } from '../rl/actorCriticAgent.js';
 import { DoubleQAgent } from '../rl/doubleQAgent.js';
 import { OptimisticAgent } from '../rl/optimisticAgent.js';
+import { ValueIterationAgent } from '../rl/valueIterationAgent.js';
+import { PolicyIterationAgent } from '../rl/policyIterationAgent.js';
 
 const agentFactory = {
   rl: RLAgent,
@@ -18,7 +20,9 @@ const agentFactory = {
   mc: MonteCarloAgent,
   ac: ActorCriticAgent,
   double: DoubleQAgent,
-  optimistic: OptimisticAgent
+  optimistic: OptimisticAgent,
+  'value-iteration': ValueIterationAgent,
+  'policy-iteration': PolicyIterationAgent
 };
 
 export function createAgent(type, options = {}) {

--- a/tests/test_agent_dropdown.js
+++ b/tests/test_agent_dropdown.js
@@ -21,6 +21,12 @@ export async function run(assert) {
   assert.ok(html.includes('<option value="optimistic">Optimistic</option>'));
   assert.ok(js.includes("import { OptimisticAgent } from '../rl/optimisticAgent.js';"));
   assert.ok(js.includes('optimistic: OptimisticAgent'));
+  assert.ok(html.includes('<option value="value-iteration">Value Iteration</option>'));
+  assert.ok(js.includes("import { ValueIterationAgent } from '../rl/valueIterationAgent.js';"));
+  assert.ok(js.includes("'value-iteration': ValueIterationAgent"));
+  assert.ok(html.includes('<option value="policy-iteration">Policy Iteration</option>'));
+  assert.ok(js.includes("import { PolicyIterationAgent } from '../rl/policyIterationAgent.js';"));
+  assert.ok(js.includes("'policy-iteration': PolicyIterationAgent"));
   assert.ok(!html.includes('<option value="dqn">'));
   assert.ok(!html.includes('@tensorflow/tfjs'));
   assert.ok(!js.includes('@tensorflow/tfjs'));

--- a/tests/test_policy_iteration_agent.js
+++ b/tests/test_policy_iteration_agent.js
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+import { PolicyIterationAgent } from '../src/rl/policyIterationAgent.js';
+
+function simulateAgent(agent, environment) {
+  let state = environment.reset();
+  let done = false;
+  let steps = 0;
+  const maxSteps = environment.size * environment.size;
+  while (!done && steps < maxSteps) {
+    const action = agent.act(state);
+    const { state: nextState, done: reachedGoal } = environment.step(action);
+    state = nextState;
+    done = reachedGoal;
+    steps += 1;
+  }
+  return { done, steps, state };
+}
+
+export async function run() {
+  const env = new GridWorldEnvironment(5);
+  env.reset();
+  const agent = new PolicyIterationAgent();
+  agent.reset(env);
+  const result = simulateAgent(agent, env);
+  assert.ok(result.done, 'Policy iteration agent should reach the goal');
+  assert.strictEqual(result.steps, (env.size - 1) * 2, 'Policy iteration agent should reach the goal using the optimal number of steps');
+  const goal = env.getGoalPosition();
+  assert.deepStrictEqual(Array.from(result.state), [goal.x, goal.y], 'Policy iteration agent should finish at the goal state');
+}

--- a/tests/test_rl_environment.js
+++ b/tests/test_rl_environment.js
@@ -43,4 +43,17 @@ export async function run() {
   stepResult = customEnv.step(1);
   assert.strictEqual(stepResult.reward, 5);
   assert.strictEqual(stepResult.done, true);
+
+  const cells = env.enumerateCells();
+  assert.strictEqual(cells.length, env.size * env.size);
+  assert.ok(cells.some(cell => cell.x === 0 && cell.y === 0));
+  const states = env.enumerateStates();
+  assert.strictEqual(states.length, cells.length);
+  const transition = env.getTransition(new Float32Array([0, 0]), 3);
+  assert.deepStrictEqual(Array.from(transition.state), [1, 0]);
+  assert.strictEqual(transition.reward, env.stepPenalty);
+  assert.strictEqual(transition.done, false);
+  const goalTransition = env.getTransition(new Float32Array([env.size - 1, env.size - 2]), 1);
+  assert.strictEqual(goalTransition.done, true);
+  assert.strictEqual(goalTransition.reward, env.goalReward);
 }

--- a/tests/test_value_iteration_agent.js
+++ b/tests/test_value_iteration_agent.js
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { GridWorldEnvironment } from '../src/rl/environment.js';
+import { ValueIterationAgent } from '../src/rl/valueIterationAgent.js';
+
+function simulateAgent(agent, environment) {
+  let state = environment.reset();
+  let done = false;
+  let steps = 0;
+  const maxSteps = environment.size * environment.size;
+  while (!done && steps < maxSteps) {
+    const action = agent.act(state);
+    const { state: nextState, done: reachedGoal } = environment.step(action);
+    state = nextState;
+    done = reachedGoal;
+    steps += 1;
+  }
+  return { done, steps, state };
+}
+
+export async function run() {
+  const env = new GridWorldEnvironment(5);
+  env.reset();
+  const agent = new ValueIterationAgent();
+  agent.reset(env);
+  const result = simulateAgent(agent, env);
+  assert.ok(result.done, 'Value iteration agent should reach the goal');
+  assert.strictEqual(result.steps, (env.size - 1) * 2, 'Value iteration agent should reach the goal using the optimal number of steps');
+  const goal = env.getGoalPosition();
+  assert.deepStrictEqual(Array.from(result.state), [goal.x, goal.y], 'Value iteration agent should finish at the goal state');
+}


### PR DESCRIPTION
## Context
- add planning-based agents that leverage deterministic environment dynamics
- expose model utilities so planners can evaluate transitions

## Description
- implement reusable planner base class plus value and policy iteration agents that plan on reset and act deterministically
- extend the grid world environment with helpers for enumerating cells and fetching deterministic transitions
- register new agents in the UI and trainer workflows, including persistence support
- cover behaviour with regression tests for planning agents and environment utilities

## Changes
- add environment helpers for state enumeration, deterministic transitions, and exported action list
- introduce planner, value-iteration, and policy-iteration agent modules with serialization support
- update agent factory, UI dropdown, and storage loader to handle planner agents
- add policy/value iteration regression tests and expand environment test coverage
- ensure trainers provide environment context to agents when resetting

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68ca6713f7b88332b9df0bda02de527f