### PR TITLE
fix: initialize multi-agent state before usage

### DIFF
--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -92,8 +92,7 @@ if (scenarioSelect) {
 }
 gridSizeInput.value = env.size;
 syncRewardInputsFromEnv(env);
-updateTrackedAgentState(1, env.getState());
-syncMultiAgentAvailability(env.size);
+
 let trainer;
 let agent;
 
@@ -122,6 +121,9 @@ const multiAgentState = {
   latestDisplayMetrics: null,
   originalLiveChart: null
 };
+
+updateTrackedAgentState(1, env.getState());
+syncMultiAgentAvailability(env.size);
 
 function isTrainerRunningInstance(targetTrainer = trainer) {
   if (!targetTrainer) return false;

--- a/tests/test_multi_agent_boot.js
+++ b/tests/test_multi_agent_boot.js
@@ -1,0 +1,82 @@
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+
+function createDom() {
+  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  return new JSDOM(html, {
+    url: 'http://localhost/',
+    pretendToBeVisual: true,
+    runScripts: 'outside-only'
+  });
+}
+
+function stubCanvas(window) {
+  window.HTMLCanvasElement.prototype.getContext = () => ({
+    clearRect() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    fillRect() {},
+    fillText() {},
+    font: ''
+  });
+}
+
+function applyGlobals(window) {
+  const assignments = {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    HTMLCanvasElement: window.HTMLCanvasElement,
+    CustomEvent: window.CustomEvent,
+    Event: window.Event,
+    requestAnimationFrame: cb => window.requestAnimationFrame(cb),
+    cancelAnimationFrame: handle => window.cancelAnimationFrame(handle),
+    performance: window.performance,
+    localStorage: window.localStorage,
+    Worker: undefined
+  };
+  const originals = new Map();
+  for (const [key, value] of Object.entries(assignments)) {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+    originals.set(key, descriptor);
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      writable: true,
+      enumerable: descriptor ? descriptor.enumerable : true,
+      value
+    });
+  }
+  return () => {
+    for (const [key, descriptor] of originals.entries()) {
+      if (descriptor === undefined) {
+        delete globalThis[key];
+      } else {
+        Object.defineProperty(globalThis, key, descriptor);
+      }
+    }
+  };
+}
+
+export async function run(assert) {
+  const dom = createDom();
+  const { window } = dom;
+  stubCanvas(window);
+  window.requestAnimationFrame = cb => setTimeout(cb, 0);
+  window.cancelAnimationFrame = handle => clearTimeout(handle);
+  window.Worker = undefined;
+
+  const restoreGlobals = applyGlobals(window);
+  try {
+    await import('../src/ui/index.js');
+    const grid = window.document.getElementById('grid');
+    assert.ok(grid.children.length > 0, 'grid should render initial cells');
+    const scenarioSelect = window.document.getElementById('scenario-select');
+    assert.ok(scenarioSelect.options.length > 1, 'scenario options should populate');
+  } finally {
+    restoreGlobals();
+    dom.window.close();
+  }
+}


### PR DESCRIPTION
## Context
- Multi-agent support caused `ReferenceError` during UI boot
- The UI crashed before rendering because state helpers ran before initialization

## Description
- Reordered the multi-agent state initialization so dependent helpers run after state creation
- Added a jsdom-based regression test to ensure the UI boots and populates scenario options without errors

## Changes
- Initialize `multiAgentState` before calling `updateTrackedAgentState` and `syncMultiAgentAvailability`
- Introduce `tests/test_multi_agent_boot.js` to validate UI startup flow

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68cb2db343fc83329b266a57f2817219