### PR TITLE
feat: resume trainer from stored state

### DIFF
--- a/src/rl/training.js
+++ b/src/rl/training.js
@@ -32,6 +32,7 @@ export class RLTrainer {
     this.metrics = this.metricsTracker.data;
     this.episodeRewards = this.metricsTracker.episodeRewards;
     this._assignEnvironmentToAgent();
+    this._initializeTrainerState();
   }
 
   _assignEnvironmentToAgent() {
@@ -146,7 +147,9 @@ export class RLTrainer {
 
   start() {
     if (this.isRunning) return;
-    this.state = this.env.reset();
+    if (!this.state) {
+      this._initializeTrainerState();
+    }
     this.isRunning = true;
     this._runLoop();
   }

--- a/tests/test_live_chart.js
+++ b/tests/test_live_chart.js
@@ -43,13 +43,12 @@ export async function run(assert) {
   const canvas = new MockCanvas();
   const chart = new LiveChart(canvas, 2);
   const trainer = new RLTrainer(agent, env, { liveChart: chart });
-  trainer.state = env.reset();
   await trainer.step();
   await trainer.step();
-  assert.deepStrictEqual(chart.rewards.map(v => +v.toFixed(2)), [-0.01, 0.99, 0]);
-  assert.deepStrictEqual(chart.avgRewards.map(v => +v.toFixed(2)), [-0.01, 0.49, 0.49]);
-  assert.deepStrictEqual(chart.epsilons.map(v => +v.toFixed(2)), [0.1, 0.1, 0.1]);
-  assert.strictEqual(canvas.ctx.clearCount, 3);
+  assert.deepStrictEqual(chart.rewards.map(v => +v.toFixed(2)), [0, -0.01, 0.99, 0]);
+  assert.deepStrictEqual(chart.avgRewards.map(v => +v.toFixed(2)), [0, -0.01, 0.49, 0.49]);
+  assert.deepStrictEqual(chart.epsilons.map(v => +v.toFixed(2)), [0.1, 0.1, 0.1, 0.1]);
+  assert.strictEqual(canvas.ctx.clearCount, 4);
   const expectedStrokes = ['rgba(148, 163, 184, 0.25)', '#5eead4', '#fbbf24', '#38bdf8'];
   for (let i = 0; i < canvas.ctx.strokeStyles.length; i += 4) {
     assert.deepStrictEqual(

--- a/tests/test_rl_trainer.js
+++ b/tests/test_rl_trainer.js
@@ -21,24 +21,29 @@ export async function run(assert) {
       reports.push({ reward, done, metrics });
     }
   });
-  trainer.state = env.reset();
   await trainer.step();
   await trainer.step();
-  assert.strictEqual(reports.length, 3);
+  assert.strictEqual(reports.length, 4);
   assert.deepStrictEqual(reports[0].metrics, {
+    episode: 1,
+    steps: 0,
+    cumulativeReward: 0,
+    epsilon: 0.1
+  });
+  assert.deepStrictEqual(reports[1].metrics, {
     episode: 1,
     steps: 1,
     cumulativeReward: -0.01,
     epsilon: 0.1
   });
-  assert.strictEqual(reports[1].done, true);
-  assert.deepStrictEqual(reports[1].metrics, {
+  assert.strictEqual(reports[2].done, true);
+  assert.deepStrictEqual(reports[2].metrics, {
     episode: 1,
     steps: 2,
     cumulativeReward: 0.99,
     epsilon: 0.1
   });
-  assert.deepStrictEqual(reports[2].metrics, {
+  assert.deepStrictEqual(reports[3].metrics, {
     episode: 2,
     steps: 0,
     cumulativeReward: 0,

--- a/tests/test_trainer_controls.js
+++ b/tests/test_trainer_controls.js
@@ -11,15 +11,19 @@ export async function run(assert) {
     currentMs = ms;
     return {};
   };
-  global.clearTimeout = () => {};
+  global.clearTimeout = () => {
+    timeoutFn = null;
+  };
 
   const env = new GridWorldEnvironment(2);
   class StubAgent {
     constructor() {
       this.epsilon = 0.3;
+      this.stateHistory = [];
     }
-    act() {
-      return 0;
+    act(state) {
+      this.stateHistory.push(Array.from(state));
+      return 3;
     }
     learn() {}
   }
@@ -40,8 +44,28 @@ export async function run(assert) {
   assert.strictEqual(currentMs, 50);
   await timeoutFn();
   trainer.pause();
+
+  const pausedState = Array.from(trainer.state);
+  assert.deepStrictEqual(pausedState, [1, 0]);
+  timeoutFn = null;
+
+  trainer.start();
+  assert.deepStrictEqual(Array.from(trainer.state), pausedState);
+  assert.strictEqual(currentMs, 50);
+  assert.ok(timeoutFn);
+  await timeoutFn();
+
+  assert.deepStrictEqual(agent.stateHistory[0], [0, 0]);
+  assert.deepStrictEqual(agent.stateHistory[1], pausedState);
+  assert.deepStrictEqual(agent.stateHistory[2], pausedState);
+
+  assert.strictEqual(epsilons.length, 4);
   assert.strictEqual(epsilons[0].toFixed(1), '0.3');
-  assert.strictEqual(epsilons[1].toFixed(1), '0.7');
+  assert.strictEqual(epsilons[1].toFixed(1), '0.3');
+  assert.strictEqual(epsilons[2].toFixed(1), '0.7');
+  assert.strictEqual(epsilons[3].toFixed(1), '0.7');
+
+  trainer.pause();
 
   global.setTimeout = originalSetTimeout;
   global.clearTimeout = originalClearTimeout;


### PR DESCRIPTION
## Context
- allow the trainer to pause and resume without losing its working environment state

## Description
- only refresh the environment when the trainer has no saved state yet so resumed runs continue smoothly
- ensure trainer construction initialises state/metrics so live components stay in sync

## Changes
- seed trainer state and metrics inside the constructor and gate start() re-initialisation on missing state
- extend trainer control coverage to assert pause/resume keeps the last state and metrics intact
- update live chart and trainer tests to account for the initial state emission

## Testing
- npm test

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68cb69dff6188332be0c7dcacfa09689