### PR TITLE
fix: guard softmax temperature edge cases

### DIFF
--- a/src/rl/actorCriticAgent.js
+++ b/src/rl/actorCriticAgent.js
@@ -33,9 +33,27 @@ export class ActorCriticAgent {
   }
 
   _softmax(prefs) {
+    const greedyProbs = index => {
+      const probs = new Array(prefs.length).fill(0);
+      if (index >= 0 && index < prefs.length) probs[index] = 1;
+      return probs;
+    };
+    const bestIndex = () => {
+      let best = 0;
+      for (let i = 1; i < prefs.length; i++) {
+        if (prefs[i] > prefs[best]) best = i;
+      }
+      return best;
+    };
+    if (!(this.temperature > 0)) {
+      return greedyProbs(bestIndex());
+    }
     const max = Math.max(...prefs);
     const exps = prefs.map(v => Math.exp((v - max) / this.temperature));
     const sum = exps.reduce((a, b) => a + b, 0);
+    if (!isFinite(sum) || sum === 0) {
+      return greedyProbs(bestIndex());
+    }
     return exps.map(v => v / sum);
   }
 

--- a/src/rl/agent.js
+++ b/src/rl/agent.js
@@ -62,13 +62,20 @@ export class RLAgent {
   }
 
   _softmax(qVals) {
+    if (!(this.temperature > 0)) {
+      return this.bestAction(qVals);
+    }
     const max = Math.max(...qVals);
     const exps = qVals.map(v => Math.exp((v - max) / this.temperature));
     const sum = exps.reduce((a, b) => a + b, 0);
-    let r = Math.random() * sum;
+    if (!isFinite(sum) || sum === 0) {
+      return this.bestAction(qVals);
+    }
+    let cumulative = 0;
+    const r = Math.random();
     for (let i = 0; i < exps.length; i++) {
-      r -= exps[i];
-      if (r <= 0) return i;
+      cumulative += exps[i] / sum;
+      if (r <= cumulative) return i;
     }
     return exps.length - 1;
   }

--- a/tests/test_actor_critic_agent.js
+++ b/tests/test_actor_critic_agent.js
@@ -76,6 +76,21 @@ export async function run(assert) {
     }
   }
 
+  {
+    const zeroTempAgent = new ActorCriticAgent({ temperature: 0 });
+    zeroTempAgent.policyTable.set(key, new Float32Array([1, 2, 3, 4]));
+    const zeroTempPrefs = Array.from(zeroTempAgent.policyTable.get(key));
+    const zeroTempProbs = zeroTempAgent._softmax(zeroTempPrefs);
+    const zeroSum = zeroTempProbs.reduce((a, b) => a + b, 0);
+    assert.deepStrictEqual(zeroTempProbs, [0, 0, 0, 1]);
+    assert.ok(Math.abs(zeroSum - 1) < 1e-8);
+    zeroTempAgent.temperature = -5;
+    const negativeTempProbs = zeroTempAgent._softmax(zeroTempPrefs);
+    const negativeSum = negativeTempProbs.reduce((a, b) => a + b, 0);
+    assert.deepStrictEqual(negativeTempProbs, [0, 0, 0, 1]);
+    assert.ok(Math.abs(negativeSum - 1) < 1e-8);
+  }
+
   const epsilonAgent = new ActorCriticAgent({ epsilon: 0.7 });
   epsilonAgent.epsilon = 0.1;
   epsilonAgent.reset();

--- a/tests/test_rl_agent.js
+++ b/tests/test_rl_agent.js
@@ -1,6 +1,7 @@
 import { RLAgent } from '../src/rl/agent.js';
 import { saveAgent, loadAgent } from '../src/rl/storage.js';
 import { mapToObject, objectToMap } from '../src/rl/utils/serialization.js';
+import { POLICIES } from '../src/rl/policies.js';
 
 export async function run(assert) {
   const map = new Map([['a', new Float32Array([1, 2])]]);
@@ -28,6 +29,14 @@ export async function run(assert) {
   greedyAgent.qTable.set(key, new Float32Array([1, 5, 3, 2]));
   const action = greedyAgent.act(state);
   assert.strictEqual(action, 1);
+
+  const softmaxAgent = new RLAgent({ policy: POLICIES.SOFTMAX, temperature: 0 });
+  softmaxAgent.qTable.set(key, new Float32Array([1, 5, 3, 2]));
+  const zeroTempAction = softmaxAgent._softmax(softmaxAgent.qTable.get(key));
+  assert.strictEqual(zeroTempAction, 1);
+  softmaxAgent.temperature = -2;
+  const negativeTempAction = softmaxAgent._softmax(softmaxAgent.qTable.get(key));
+  assert.strictEqual(negativeTempAction, 1);
 
   const data = greedyAgent.toJSON();
   const loadedAgent = RLAgent.fromJSON(data);


### PR DESCRIPTION
## Context
- Softmax policies should gracefully handle zero or negative temperatures so action selection remains stable.
- Current agents throw off the sampler when the temperature is non-positive, which can produce NaNs or erratic policies.

## Description
- Clamp softmax sampling to a greedy policy whenever the configured temperature is zero, negative, or causes the distribution to collapse.
- Keep the probability distributions normalised and deterministic in these fallback scenarios to avoid introducing numerical noise.

## Changes
- Guard RLAgent softmax sampling against non-positive temperatures and invalid sums, falling back to the best action.
- Mirror the same guard for ActorCriticAgent while producing properly normalised probability vectors.
- Add regression tests that cover zero and negative temperatures for both agents’ softmax implementations.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68ccae1af9b883329965870b37435a75