### PR TITLE
test: verify multi-agent metrics aggregation

### DIFF
--- a/tests/test_multi_agent_boot.js
+++ b/tests/test_multi_agent_boot.js
@@ -68,6 +68,65 @@ export async function run(assert) {
   window.cancelAnimationFrame = handle => clearTimeout(handle);
   window.Worker = undefined;
 
+  class MockTrainer {
+    constructor(agent, env, options = {}) {
+      this.agent = agent;
+      this.env = env;
+      this.intervalMs = options.intervalMs ?? 100;
+      this.maxSteps = options.maxSteps ?? 50;
+      this.liveChart = options.liveChart ?? null;
+      this.metrics = {
+        episode: 1,
+        steps: 0,
+        cumulativeReward: 0,
+        epsilon: agent?.epsilon ?? 1
+      };
+      this.isRunning = false;
+      this.onStepHandler = options.onStep || null;
+      this.onProgressHandler = options.onProgress || null;
+      MockTrainer.instances.push(this);
+    }
+
+    start() {
+      this.isRunning = true;
+    }
+
+    pause() {
+      this.isRunning = false;
+    }
+
+    reset() {
+      this.isRunning = false;
+    }
+
+    resetTrainerState() {
+      this.isRunning = false;
+    }
+
+    setIntervalMs(ms) {
+      if (Number.isFinite(ms)) {
+        this.intervalMs = ms;
+      }
+    }
+
+    setMaxSteps(limit) {
+      if (Number.isFinite(limit)) {
+        this.maxSteps = limit;
+      }
+    }
+
+    setEnvironment(env) {
+      this.env = env;
+    }
+  }
+
+  MockTrainer.instances = [];
+
+  window.__OBLIX_TEST_HARNESS__ = true;
+  window.__OBLIX_TEST_OVERRIDES__ = {
+    RLTrainer: MockTrainer
+  };
+
   const restoreGlobals = applyGlobals(window);
   try {
     await import('../src/ui/index.js');
@@ -75,6 +134,67 @@ export async function run(assert) {
     assert.ok(grid.children.length > 0, 'grid should render initial cells');
     const scenarioSelect = window.document.getElementById('scenario-select');
     assert.ok(scenarioSelect.options.length > 1, 'scenario options should populate');
+
+    const gridSizeInput = window.document.getElementById('grid-size');
+    gridSizeInput.value = '12';
+    gridSizeInput.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    const multiAgentControls = window.document.getElementById('multi-agent-controls');
+    assert.ok(!multiAgentControls.classList.contains('is-hidden'), 'multi-agent controls become visible on large grid');
+
+    const testApi = window.__oblixTestApi;
+    assert.ok(testApi, 'test harness API should be exposed');
+    assert.strictEqual(typeof testApi.setAgentCount, 'function', 'setAgentCount should be available');
+
+    const initialTrainerCount = MockTrainer.instances.length;
+    assert.ok(initialTrainerCount >= 1, 'base trainer instance should exist');
+
+    const agentCountSelect = window.document.getElementById('agent-count');
+    agentCountSelect.value = '3';
+    agentCountSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    assert.strictEqual(MockTrainer.instances.length, initialTrainerCount + 2, 'increasing agent count instantiates additional trainers');
+    assert.strictEqual(testApi.getMultiAgentState().agentCount, 3, 'internal agent count should reflect selection');
+
+    const trainer = testApi.getTrainer();
+    const liveChart = testApi.getLiveChart();
+    assert.ok(liveChart, 'live chart instance should be available');
+    assert.strictEqual(trainer.liveChart, null, 'base trainer live chart is disabled during multi-agent runs');
+
+    const pushes = [];
+    liveChart.push = (reward, epsilon) => {
+      pushes.push({ reward, epsilon });
+    };
+
+    const baseMetrics = { episode: 10, steps: 20, cumulativeReward: 30, epsilon: 0.5 };
+    const agent2Metrics = { episode: 8, steps: 40, cumulativeReward: 10, epsilon: 0.3 };
+    const agent3Metrics = { episode: 12, steps: 50, cumulativeReward: 20, epsilon: 0.1 };
+
+    trainer.metrics = baseMetrics;
+    testApi.handleAdditionalProgress(2, { x: 1, y: 1 }, 0, false, agent2Metrics);
+    testApi.handleAdditionalProgress(3, { x: 2, y: 2 }, 0, false, agent3Metrics);
+    testApi.handleProgress({ x: 0, y: 0 }, 0, false, baseMetrics);
+
+    const aggregated = testApi.computeAggregatedMetrics(baseMetrics);
+    assert.strictEqual(aggregated.episode, 12, 'aggregated metrics use the max episode value');
+    assert.ok(Math.abs(aggregated.steps - (20 + 40 + 50) / 3) < 1e-6, 'aggregated steps average across agents');
+    assert.ok(Math.abs(aggregated.cumulativeReward - (30 + 10 + 20) / 3) < 1e-6, 'aggregated reward averages across agents');
+    assert.ok(Math.abs(aggregated.epsilon - (0.5 + 0.3 + 0.1) / 3) < 1e-6, 'aggregated epsilon averages finite values');
+
+    const getText = id => window.document.getElementById(id).textContent;
+    assert.strictEqual(getText('episode'), '12', 'episode display reflects aggregated value');
+    assert.strictEqual(getText('steps'), '37', 'steps display rounds aggregated average');
+    assert.strictEqual(getText('reward'), '20.00', 'reward display reflects aggregated average');
+    assert.strictEqual(getText('epsilon'), '0.30', 'epsilon display reflects aggregated average');
+    assert.strictEqual(window.document.getElementById('epsilon-value').textContent, '0.30', 'epsilon pill mirrors aggregated epsilon');
+
+    assert.strictEqual(pushes.length, 1, 'live chart receives a single aggregated update');
+    assert.ok(Math.abs(pushes[0].reward - 20) < 1e-6, 'live chart reward uses aggregated value');
+    assert.ok(Math.abs(pushes[0].epsilon - 0.3) < 1e-6, 'live chart epsilon uses aggregated value');
+
+    agentCountSelect.value = '1';
+    agentCountSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
+    assert.strictEqual(testApi.getTrainer().liveChart, liveChart, 'live chart reattaches when returning to single agent');
   } finally {
     restoreGlobals();
     dom.window.close();


### PR DESCRIPTION
## Context
The multi-agent dashboard needs automated coverage to ensure aggregated metrics and chart behavior stay correct when additional trainers are spawned.

## Description
Adds a deterministic jsdom test harness that exercises the multi-agent controls, mocking trainers so we can assert on aggregated metrics and live chart updates.

## Changes
- Allow injecting a trainer override and expose a guarded testing API from `src/ui/index.js` for harness-only validation.
- Extend `tests/test_multi_agent_boot.js` with a mocked trainer to verify aggregated metrics, DOM updates, and live chart behavior when agent count increases.
- Ensure multi-agent selection instantiates extra trainers and reinstates live chart updates when returning to a single agent.

Passing to @codex for code review

------
https://chatgpt.com/codex/tasks/task_e_68cf95c189fc8332a988cb9e89e6a312